### PR TITLE
Emojis: Remove autocompletion on ':' character.

### DIFF
--- a/editor/src/kroqed-editor/codeview/nodeview.ts
+++ b/editor/src/kroqed-editor/codeview/nodeview.ts
@@ -137,7 +137,7 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 			effects: this._autocompletionCompartment.reconfigure(
 				autocompletion({
 					// Add autocompletion sources
-					override: [completionFunction, coqCompletionSource, symbolCompletionSource, emojiCompletionSource]
+					override: [completionFunction, coqCompletionSource, symbolCompletionSource]
 				})
 			)
 		})


### PR DESCRIPTION
Removed the (emoji)autocompletion on the ':' character as this character is also used in proofs.