### PR TITLE
Input area colors better reflect status.

### DIFF
--- a/editor/src/kroqed-editor/qedStatus.ts
+++ b/editor/src/kroqed-editor/qedStatus.ts
@@ -1,8 +1,9 @@
 // Importing necessary modules from prosemirror-state and prosemirror-view
-import { EditorState, Plugin, PluginKey } from 'prosemirror-state';
+import { EditorState, Plugin, PluginKey, PluginSpec } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 import { findDescendantsWithType } from './kroqed-utils';
 import { QedStatus } from '../../../shared';
+import { Editor } from './editor';
 
 // Define interface for UpdateStatusPluginState
 export interface IUpdateStatusPluginState {
@@ -25,57 +26,75 @@ const statusToDecoration = (status: QedStatus) => {
 };
 
 // Plugin specification
-let UpdateStatusPluginSpec = {
-  key: UPDATE_STATUS_PLUGIN_KEY,
-  state: {
-    // The function to initialize the plugin state
-    init(config, instance){
-      return {
-        status: [],
-      };
-    },
-    // Function to apply updates to the plugin state
-    apply(tr, value, oldState, newState){
-      const newStatus = tr.getMeta(UPDATE_STATUS_PLUGIN_KEY);
-      if (newStatus === undefined) {
-        return value;
-      } else {
+let UpdateStatusPluginSpec = (editor: Editor): PluginSpec<IUpdateStatusPluginState> => {
+  return {
+    key: UPDATE_STATUS_PLUGIN_KEY,
+    state: {
+      // The function to initialize the plugin state
+      init(config, instance){
         return {
-          status: newStatus,
+          status: [],
         };
+      },
+      // Function to apply updates to the plugin state
+      apply(tr, value, oldState, newState){
+        const newStatus = tr.getMeta(UPDATE_STATUS_PLUGIN_KEY);
+        if (newStatus === undefined) {
+          return value;
+        } else {
+          return {
+            status: newStatus,
+          };
+        }
       }
-    }
-  },
-  props: {
-    // Function to compute decorations based on the plugin state
-    decorations: (state) => {
-      const statusUpdate = UPDATE_STATUS_PLUGIN_KEY.getState(state)?.status;
-      if (statusUpdate && statusUpdate.length > 0) {
-        // Get all input nodes in the document
-        const inputNodeType = state.schema.nodes.input;
-        const inputNodes = findDescendantsWithType(state.doc, true, inputNodeType);
-
-        if (!inputNodes || statusUpdate.length !== inputNodes.length) return null;
-
-        let decorations: Decoration[] = [];
-        inputNodes.forEach((inputNode, index) => {
-          if (statusUpdate[index] !== undefined) {
-            let newStatusUpdate = statusUpdate[index];
-            if (inputNode.node.attrs.status !== newStatusUpdate) {
-              let decoration = Decoration.node(inputNode.pos, inputNode.pos + inputNode.node.nodeSize, {
-                class: statusToDecoration(newStatusUpdate),
-              });
-              decorations.push(decoration);
-            }
-          }
-        });
-
-        return DecorationSet.create(state.doc, decorations);
-      }
-      return null;
     },
-  },
-};
+    props: {
+      // Function to compute decorations based on the plugin state
+      decorations: (state: EditorState) => {
+        const statusUpdate = UPDATE_STATUS_PLUGIN_KEY.getState(state)?.status;
+        if (statusUpdate && statusUpdate.length > 0) {
+          // Get all input nodes in the document
+          const inputNodeType = state.schema.nodes.input;
+          const inputNodes = findDescendantsWithType(state.doc, true, inputNodeType);
+
+          if (!inputNodes || statusUpdate.length !== inputNodes.length) return null;
+
+          let decorations: Decoration[] = [];
+          inputNodes.forEach((inputNode, index) => {
+            if (statusUpdate[index] !== undefined) {
+              let newStatusUpdate = statusUpdate[index];
+              if (inputNode.node.attrs.status !== newStatusUpdate) {
+                // This is (probably) the place where we check for errors in the proof. 
+                // A proof should not be accepted if it includes a faulty coq statement.
+
+                const start = inputNode.pos;
+                const end = start + inputNode.node.nodeSize;
+                const thingies = editor.getDiagnosticsInRange(start, end);
+                let className = statusToDecoration(newStatusUpdate);
+                if (thingies.length > 0) {
+                  if (thingies.find((value) => value.severity == 0)) {
+                    // Coq error in proof.
+                    className += "-contains-error";
+                  } else {
+                    className += "-contains-warning";
+                  }
+                }
+
+                let decoration = Decoration.node(start, end, {
+                  class: className,
+                });
+                decorations.push(decoration);
+              }
+            }
+          });
+
+          return DecorationSet.create(state.doc, decorations);
+        }
+        return null;
+      },
+    },
+  };
+}
 
 // Create a new instance of the plugin
-export const updateStatusPlugin = new Plugin(UpdateStatusPluginSpec);
+export const updateStatusPlugin = (editor: Editor) => { return new Plugin(UpdateStatusPluginSpec(editor)) };

--- a/editor/src/kroqed-editor/styles/input-area.css
+++ b/editor/src/kroqed-editor/styles/input-area.css
@@ -21,8 +21,19 @@
   background-color: lightgreen;
 }
 
-.inputarea.incomplete::before {
+.inputarea.proven-contains-error::before {
+  width: 8px;
+  background-color: blue;
+}
+
+.inputarea.proven-contains-warning::before {
+  width: 8px;
+  background-color: orange;
+}
+
+.inputarea.incomplete::before,
+.inputarea.incomplete-contains-error::before,
+.inputarea.incomplete-contains-warning::before {
   width: 8px;
   background-color: lightcoral;
 }
-  

--- a/editor/src/kroqed-editor/styles/input-area.css
+++ b/editor/src/kroqed-editor/styles/input-area.css
@@ -18,22 +18,22 @@
 
 .inputarea.proven::before {
   width: 8px;
-  background-color: lightgreen;
+  background-color: var(--vscode-terminal-ansiGreen);
 }
 
 .inputarea.proven-contains-error::before {
   width: 8px;
-  background-color: blue;
+  background-color: var(--vscode-charts-orange);
 }
 
 .inputarea.proven-contains-warning::before {
   width: 8px;
-  background-color: orange;
+  background-color: var(--vscode-terminal-ansiYellow);
 }
 
 .inputarea.incomplete::before,
 .inputarea.incomplete-contains-error::before,
 .inputarea.incomplete-contains-warning::before {
   width: 8px;
-  background-color: lightcoral;
+  background-color: var(--vscode-terminal-ansiRed);
 }

--- a/editor/src/kroqed-editor/styles/input-area.css
+++ b/editor/src/kroqed-editor/styles/input-area.css
@@ -21,11 +21,6 @@
   background-color: var(--vscode-terminal-ansiGreen);
 }
 
-.inputarea.proven-contains-error::before {
-  width: 8px;
-  background-color: var(--vscode-charts-orange);
-}
-
 .inputarea.proven-contains-warning::before {
   width: 8px;
   background-color: var(--vscode-terminal-ansiYellow);
@@ -33,7 +28,8 @@
 
 .inputarea.incomplete::before,
 .inputarea.incomplete-contains-error::before,
-.inputarea.incomplete-contains-warning::before {
+.inputarea.incomplete-contains-warning::before, 
+.inputarea.proven-contains-error::before {
   width: 8px;
   background-color: var(--vscode-terminal-ansiRed);
 }


### PR DESCRIPTION
Proofs that are correct, but include a coq error now appear incorrect. 

Changes:
- Make input area colors theme dependent. 
- Save current diagnostics. 
- When updating the color of an input area, query diagnostics to make sure there is no coq error in the input area. 
