### PR TITLE
added spinner next to progressBar

### DIFF
--- a/editor/src/kroqed-editor/editor.ts
+++ b/editor/src/kroqed-editor/editor.ts
@@ -96,6 +96,7 @@ export class Editor {
 			// Hack to forcefully remove the 'old' menubar
 			document.querySelector(".menubar")?.remove();
 			document.querySelector(".progress-bar")?.remove();
+			document.querySelector(".spinner-container")?.remove();
 			this._view.dom.remove();
 		}
 

--- a/editor/src/kroqed-editor/progressBar.ts
+++ b/editor/src/kroqed-editor/progressBar.ts
@@ -13,8 +13,16 @@ export interface IProgressPluginState {
 // Plugin key for the progress plugin
 export const PROGRESS_PLUGIN_KEY = new PluginKey<IProgressPluginState>("prosemirror-progressBar");
 
+function startSpinner(spinnerContainer) {
+  spinnerContainer.classList.add('spinner');
+}
+
+function stopSpinner(spinnerContainer) {
+  spinnerContainer.classList.remove('spinner');
+}
+
 // Function to create a progress bar given the progress state and the container for the progress bar
-function createProgressBar(progressState, progressBarContainer) {
+function createProgressBar(progressState, progressBarContainer, spinnerContainer) {
   const { progressParams, resetProgressBar, endLine, startLine } = progressState;
 
   // Remove existing progress bar text
@@ -58,8 +66,10 @@ function createProgressBar(progressState, progressBarContainer) {
   // Set the text of the span
   if (progressParams.progress.length > 0) {
     progressBarText.textContent = `Progress: ${Math.round((progressBar.value / progressBar.max) * 100)}%, Currently at line: ${startLine + 1}`;
+    startSpinner(spinnerContainer);
   } else {
     progressBarText.textContent = `Progress: ${Math.round((progressBar.value / progressBar.max) * 100)}%`;
+    stopSpinner(spinnerContainer);
   }
 
   progressBarContainer.appendChild(progressBarText);
@@ -100,6 +110,8 @@ let ProgressBarPluginSpec: PluginSpec<IProgressPluginState> = {
     // Create a container for the progress bar
     let progressBarContainer = document.createElement('div');
     progressBarContainer.className = 'progress-bar';
+    let spinnerContainer = document.createElement('div');
+    spinnerContainer.className = 'spinner-container';
 
     // Insert the progress bar container into the DOM
     let parentNode = editorView.dom.parentNode;
@@ -107,13 +119,14 @@ let ProgressBarPluginSpec: PluginSpec<IProgressPluginState> = {
       throw Error("editorView.dom.parentNode cannot be null here");
     }
     parentNode.insertBefore(progressBarContainer, editorView.dom);
+    parentNode.insertBefore(spinnerContainer, editorView.dom);
 
     return {
       update(view, prevState) {
         // Update the progress bar with the current state
         let progressState = PROGRESS_PLUGIN_KEY.getState(view.state);
         if (progressState) {
-          createProgressBar(progressState, progressBarContainer);
+          createProgressBar(progressState, progressBarContainer, spinnerContainer);
         }
       },
     };

--- a/editor/src/kroqed-editor/styles/index.ts
+++ b/editor/src/kroqed-editor/styles/index.ts
@@ -24,5 +24,8 @@ import "./coqdoc.css";
 // for the progressBar
 import "./progressBar.css";
 
+// for the spinner
+import "./spinner.css";
+
 // for the freeze effect skull
 import "./freeze.css";

--- a/editor/src/kroqed-editor/styles/progressBar.css
+++ b/editor/src/kroqed-editor/styles/progressBar.css
@@ -1,9 +1,11 @@
 .progress-bar {
     position: sticky;
+    display: inline-block;
     top: 0;
     margin-bottom: 1rem;
+    margin-right: 0.2rem;
     z-index: 9000;
-    width: 95%;
+    width: 93%;
 }
 
 /* Here we apply styles to the progress bar */

--- a/editor/src/kroqed-editor/styles/progressBar.css
+++ b/editor/src/kroqed-editor/styles/progressBar.css
@@ -3,7 +3,7 @@
     top: 0;
     margin-bottom: 1rem;
     z-index: 9000;
-    width: 100%;
+    width: 95%;
 }
 
 /* Here we apply styles to the progress bar */
@@ -25,7 +25,7 @@
 
 /* Here we define styles for the progress bar in different browsers */
 .progress-bar progress::-webkit-progress-bar {
-    background-color: var(--vscode-quickInput-background);
+    background-color: var(--vscode-textCodeBlock-background);
 }
 
 .progress-bar progress::-webkit-progress-value {

--- a/editor/src/kroqed-editor/styles/progressBar.css
+++ b/editor/src/kroqed-editor/styles/progressBar.css
@@ -5,7 +5,7 @@
     margin-bottom: 1rem;
     margin-right: 0.2rem;
     z-index: 9000;
-    width: 93%;
+    width: 90%;
 }
 
 /* Here we apply styles to the progress bar */

--- a/editor/src/kroqed-editor/styles/spinner.css
+++ b/editor/src/kroqed-editor/styles/spinner.css
@@ -1,18 +1,18 @@
 .spinner-container {
-    position: fixed;
-    top: 8px;
-    right: 5px;
-    padding: 0px;
+    position: sticky;
+    display: inline-block;
+    top: 0;
+    vertical-align: top;
     z-index: 9999;
 }
 
 /* Define the spinner animation */
 .spinner {
-  border: 4px solid var(--vscode-quickInput-background);
-  border-top: 4px solid var(--vscode-button-background);
-  border-radius: 50%;
-  width: 1rem;
-  height: 1rem;
+  border: 0.3rem solid var(--vscode-quickInput-background);
+  border-top: 0.3rem solid var(--vscode-button-background);
+  border-radius: 100%;
+  width: 0.8rem;
+  height: 0.8rem;
   background-color: var(--vscode-quickInput-background);
   animation: spin 1s linear infinite;
 }

--- a/editor/src/kroqed-editor/styles/spinner.css
+++ b/editor/src/kroqed-editor/styles/spinner.css
@@ -1,0 +1,24 @@
+.spinner-container {
+    position: fixed;
+    top: 9px;
+    right: 10px;
+    padding: 0px;
+    z-index: 9999;
+}
+
+/* Define the spinner animation */
+.spinner {
+  border: 4px solid var(--vscode-quickInput-background);
+  border-top: 4px solid var(--vscode-button-background);
+  border-radius: 50%;
+  width: 15px;
+  height: 15px;
+  background-color: var(--vscode-quickInput-background);
+  animation: spin 1s linear infinite;
+}
+
+/* Keyframes for the spinner animation */
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/editor/src/kroqed-editor/styles/spinner.css
+++ b/editor/src/kroqed-editor/styles/spinner.css
@@ -1,7 +1,7 @@
 .spinner-container {
     position: fixed;
-    top: 9px;
-    right: 10px;
+    top: 8px;
+    right: 5px;
     padding: 0px;
     z-index: 9999;
 }
@@ -11,8 +11,8 @@
   border: 4px solid var(--vscode-quickInput-background);
   border-top: 4px solid var(--vscode-button-background);
   border-radius: 50%;
-  width: 15px;
-  height: 15px;
+  width: 1rem;
+  height: 1rem;
   background-color: var(--vscode-quickInput-background);
   animation: spin 1s linear infinite;
 }


### PR DESCRIPTION
spinner added next to the progressBar. The code for the spinner can be found in progressBar.ts, with two simple functions to start and stop the spinner and a few lines to add the html.

spiner.css defines the style.

The progressBar width was slightly reduced, and the background color was changed to have better contrast and better show the progress (it is easier to tell what 100% of the progessBar is this way). This was needed because with the addition of the spinner it was hard to tell where the progressBar ends.