### PR TITLE
Fixed bug that allowed students to delete input areas

### DIFF
--- a/editor/src/kroqed-editor/editor.ts
+++ b/editor/src/kroqed-editor/editor.ts
@@ -218,11 +218,8 @@ export class Editor {
 			progressBarPlugin,
 			menuPlugin(this._schema, this._filef, this._userOS),
 			keymap({
-				// TODO: How much of these are still necessary?
-				"Backspace": chainCommands(deleteNodeIfEmpty, deleteSelection),
-				"Enter" : chainCommands(newlineInCode, createParagraphNear, liftEmptyBlock, splitBlock),
-				"Mod-Enter": chainCommands(newlineInCode, createParagraphNear, splitBlock),
-				"Delete": chainCommands(deleteNodeIfEmpty, deleteSelection),
+				"Backspace": deleteSelection,
+				"Delete": deleteSelection,
 				"Mod-m": cmdInsertMarkdown(this._schema, this._filef, InsertionPlace.Underneath),
 				"Mod-M": cmdInsertMarkdown(this._schema, this._filef, InsertionPlace.Above),
 				"Mod-q": cmdInsertCoq(this._schema, this._filef, InsertionPlace.Underneath),


### PR DESCRIPTION
Fixed the bug that allowed students to delete an input area. Before the fix it was possible for students to delete an input area containing only a 'coq' cell by pressing backspace in the emptied coq cell. 

Changes: 
- Update editor keymap (remove binding `deleteNodeIfEmpty` from the `Delete` and `Backspace` keys)
- Removed unused editor keybindings