### PR TITLE
Custom new file command

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
     ],
     "commands": [
       {
+        "command": "waterproof.newWaterproofDocument",
+        "title": "Waterproof: Create new waterproof document",
+        "shortTitle": "New waterproof document"
+      },
+      {
         "command": "waterproof.start",
         "title": "Waterproof: Start the document checker"
       },
@@ -81,6 +86,15 @@
         "title": "Waterproof: Restart the document checker"
       }
     ],
+    "menus": {
+      "file/newFile": [
+        {
+          "command": "waterproof.newWaterproofDocument",
+          "group": "file",
+          "when": "!virtualWorkspace"
+        }
+      ]
+    },
     "keybindings": [
       {
         "command": "waterproof.goals",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const newFileContent = "<input-area>\n```coq\nLemma\n```\n</input-area>";
+export const newFileContent = "<input-area>\n```coq\n(* Empty Waterproof Document *)\n```\n</input-area>";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const newFileContent = "<input-area>\n```coq\nLemma\n```\n</input-area>";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,8 @@ import {
     TextDocument,
     WorkspaceConfiguration,
     commands,
-    workspace
-} from "vscode";
+    workspace,
+    window} from "vscode";
 import { LanguageClientOptions, RevealOutputChannelOn } from "vscode-languageclient";
 
 import { IExecutor, IGoalsComponent, IStatusComponent } from "./components";
@@ -24,6 +24,8 @@ import { CommonExecute } from "./webviews/standardviews/commonExecute";
 import { ExecutePanel } from "./webviews/standardviews/execute";
 import { SymbolsPanel } from "./webviews/standardviews/symbols";
 import { TacticsPanel } from "./webviews/standardviews/tactics";
+
+import { newFileContent } from "./constants";
 
 /**
  * Main extension class
@@ -134,6 +136,30 @@ export class Coqnitive implements Disposable {
         this.registerCommand("restart", this.restartClient);
         this.registerCommand("toggle", this.toggleClient);
         this.registerCommand("stop", this.stopClient);
+
+        // Register the new Waterproof Document command
+        this.registerCommand("newWaterproofDocument", this.newFileCommand);
+    }
+
+    /**
+     * Handle the newWaterproofDocument command. 
+     * This command can be either activated by the user via the 'command palette' 
+     * or by using the File -> New File... option. 
+     */
+    private async newFileCommand(): Promise<void> {
+
+        window.showSaveDialog({filters: {'Waterproof': ["mv", "v"]}, title: "New Waterproof Document"}).then((uri) => {
+            if (!uri) {
+                window.showErrorMessage("Something went wrong in creating a new waterproof document");
+                return;
+            }
+
+            workspace.fs.writeFile(uri, Buffer.from(newFileContent)).then(() => {
+                // Open the file using the waterproof editor
+                // TODO: Hardcoded `coqEditor.coqEditor`.
+                commands.executeCommand("vscode.openWith", uri, "coqEditor.coqEditor");
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
Added a custom command for creating a new waterproof document. 
This command is accessible via the Command Palette and via the 'File -> New File...' menu. 
New file contents can be changed by updating the `newFileContent` string in [/src/constants.ts](https://github.com/impermeable/waterproof-vscode/blob/328ac6f26fe6e3347eb8db2280b22f7089c8e9ba/src/constants.ts)