### PR TITLE
Added activeLineIndicator for focused code blocks

### DIFF
--- a/editor/src/kroqed-editor/codeview/coqTheme.json
+++ b/editor/src/kroqed-editor/codeview/coqTheme.json
@@ -41,6 +41,7 @@
 	  "backgroundColor": "#6199ff2f"
 	},
 	".cm-activeLine": {"backgroundColor": "#6699ff0b"},
+    "&:not(.cm-focused) .cm-activeLine": { "backgroundColor": "transparent"},
 	".cm-selectionMatch": {"backgroundColor": "#aafe661a"},
 	"&.cm-focused .cm-matchingBracket, &.cm-focused .cm-nonmatchingBracket": {
 	  "backgroundColor": "#bad0f847"

--- a/editor/src/kroqed-editor/codeview/nodeview.ts
+++ b/editor/src/kroqed-editor/codeview/nodeview.ts
@@ -5,6 +5,7 @@ import { coq, coqSyntaxHighlighting } from "./lang-pack"
 import { Compartment, EditorState, Extension } from "@codemirror/state"
 import {
 	EditorView as CodeMirror, keymap as cmKeymap,
+	highlightActiveLine,
 	lineNumbers, placeholder} from "@codemirror/view"
 import { Node, Schema } from "prosemirror-model"
 import { EditorView } from "prosemirror-view"
@@ -72,6 +73,7 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 				customTheme,
 				syntaxHighlighting(defaultHighlightStyle),
 				coq(),
+                highlightActiveLine(),
 				coqSyntaxHighlighting(),
 				CodeMirror.updateListener.of(update => this.forwardUpdate(update)),
 				placeholder("Empty code cell")


### PR DESCRIPTION
Enabled the activeLineIndicator and made the indicator be transparent for unfocused code blocks so it only "shows up" for the focused code blocks.
The color of the activeLine can be changed if needed.