### PR TITLE
Client: Use the beginning of the sentence when executing commands.

### DIFF
--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -158,6 +158,11 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
             return this.start();
         }
 
+        getBeginningOfCurrentSentence(): Position | undefined {
+            if (!this.activeCursorPosition) return undefined;
+            return this.sentenceManager.getBeginningOfSentence(this.activeCursorPosition);
+        }
+
         getEndOfCurrentSentence(): Position | undefined {
             if (!this.activeCursorPosition) return undefined;
             return this.sentenceManager.getEndOfSentence(this.activeCursorPosition);

--- a/src/lsp-client/clientTypes.ts
+++ b/src/lsp-client/clientTypes.ts
@@ -45,6 +45,13 @@ export interface ICoqLspClient {
     getEndOfCurrentSentence(): Position | undefined;
 
     /**
+     * Returns the beginning position of the currently selected sentence, i.e., the Coq sentence in the
+     * active document in which the text cursor is located. Only returns `undefined` if no sentences
+     * are known. This is really just the end position of the previous sentence.
+     */
+    getBeginningOfCurrentSentence(): Position | undefined
+
+    /**
      * Creates parameter object for a goals request.
      */
     createGoalsRequestParameters(document: TextDocument, position: Position): GoalRequest;

--- a/src/lsp-client/commandExecutor.ts
+++ b/src/lsp-client/commandExecutor.ts
@@ -33,7 +33,8 @@ export async function executeCommand(client: CoqLspClient, command: string): Pro
         throw new Error("Cannot execute command; there is no active document.");
     }
 
-    const commandPosition = client.getEndOfCurrentSentence();
+    // We execute the command at the end of the previous sentence.
+    const commandPosition = client.getBeginningOfCurrentSentence();
     if (!commandPosition) {
         throw new Error("Cannot execute command; the document contains no Coq code.");
     }

--- a/src/lsp-client/sentenceManager.ts
+++ b/src/lsp-client/sentenceManager.ts
@@ -63,11 +63,13 @@ export class SentenceManager implements IFileProgressComponent {
         const n = this.sentenceEndPositions.length;
         if (n === 0) return undefined;
         const i = this.getRank(position) - 1;
-
-        if (i === n)
-            return strict ? undefined : this.sentenceEndPositions[n-1];
-        else
-            return this.sentenceEndPositions[i];
+        const sentenceEndPosition = this.sentenceEndPositions[i];
+        if (this.sentenceEndPositions[i+1].isEqual(position)) {
+            return this.sentenceEndPositions[i+1];
+        } else {
+            return sentenceEndPosition;
+        }
+        
     }
 
     /**

--- a/src/lsp-client/sentenceManager.ts
+++ b/src/lsp-client/sentenceManager.ts
@@ -53,6 +53,24 @@ export class SentenceManager implements IFileProgressComponent {
     }
 
     /**
+     * Returns the beginning position of the sentence in which `position` is located.
+     * That is, the end position of the previous sentence.
+     * If `strict`, return `undefined` if no sentences are known or if `position` is after the last.
+     * In the second case, if not `strict`, simply return the last sentence.
+     */
+    getBeginningOfSentence(position: Position, strict: boolean = false): Position | undefined {
+        // FIXME: This is really just a hack to get things to work for now.
+        const n = this.sentenceEndPositions.length;
+        if (n === 0) return undefined;
+        const i = this.getRank(position) - 1;
+
+        if (i === n)
+            return strict ? undefined : this.sentenceEndPositions[n-1];
+        else
+            return this.sentenceEndPositions[i];
+    }
+
+    /**
      * Returns the end position of the sentence in which `position` is located.
      * If `strict`, return `undefined` if no sentences are known or if `position` is after the last.
      * In the second case, if not `strict`, simply return the last sentence.


### PR DESCRIPTION
The beginning of the current sentence (ie. the sentence that the cursor is currently in) refers to the end position of the previous sentence, since we do not have enough information to actually find the beginning.

This PR changes the working of the `commandExecutor` such that it now uses the end of the previous sentence when executing commands, instead of the end. 