### PR TITLE
Editor: Remove `@codemirror` default keymap.

### DIFF
--- a/editor/src/kroqed-editor/codeview/nodeview.ts
+++ b/editor/src/kroqed-editor/codeview/nodeview.ts
@@ -1,5 +1,5 @@
 import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion } from "@codemirror/autocomplete";
-import { defaultKeymap, indentWithTab } from "@codemirror/commands";
+import { indentWithTab } from "@codemirror/commands";
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { coq, coqSyntaxHighlighting } from "./lang-pack"
 import { Compartment, EditorState, Extension } from "@codemirror/state"
@@ -12,7 +12,7 @@ import { EditorView } from "prosemirror-view"
 import { customTheme } from "./color-scheme"
 import { symbolCompletionSource, coqCompletionSource, tacticCompletionSource } from "./autocomplete";
 import { EmbeddedCodeMirrorEditor } from "../embedded-codemirror";
-import { linter, LintSource, Diagnostic, forceLinting } from "@codemirror/lint";
+import { linter, LintSource, Diagnostic } from "@codemirror/lint";
 
 /**
  * Export CodeBlockView class that implements the custom codeblock nodeview.
@@ -67,8 +67,7 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 				}),
 				cmKeymap.of([
 					indentWithTab,
-					...this.embeddedCodeMirrorKeymap(),
-					...defaultKeymap,
+					...this.embeddedCodeMirrorKeymap()
 				]),
 				customTheme,
 				syntaxHighlighting(defaultHighlightStyle),

--- a/editor/src/kroqed-editor/markup-views/switchable-view/EditableView.ts
+++ b/editor/src/kroqed-editor/markup-views/switchable-view/EditableView.ts
@@ -1,4 +1,4 @@
-import { defaultKeymap, indentWithTab } from "@codemirror/commands"
+import { indentWithTab } from "@codemirror/commands"
 import {
 	EditorView as CodeMirror, ViewUpdate, keymap as cmKeymap,
 	placeholder
@@ -45,7 +45,6 @@ export class EditableView extends EmbeddedCodeMirrorEditor {
 				cmKeymap.of([
 					indentWithTab,
 					...this.embeddedCodeMirrorKeymap(),
-					...defaultKeymap
 				]),
 				CodeMirror.updateListener.of(update => this.forwardUpdate(update)),
 				placeholder("Empty..."),


### PR DESCRIPTION
We remove the default `codemirror` keymap as we do not support all types of edits that it makes.

This prevents `Alt-UpArrow`/`Alt-DownArrow` from breaking the current document.

This removes *all* keybindings, except for `Tab` which is bound to indent line.

@jim-portegies @jellooo038 If there are any keybindings we would like to keep, we can add those manually.