### PR TITLE
Editor: Force `@codemirror` linter to run only when editor is idle.

### DIFF
--- a/editor/src/kroqed-editor/codeview/debouncer.ts
+++ b/editor/src/kroqed-editor/codeview/debouncer.ts
@@ -1,0 +1,18 @@
+export class Debouncer {
+    private _func: () => void;
+    private _delay: number;
+
+    private timer: number | undefined;
+
+    constructor(delay: number, func: () => void) {
+        this._func = func;
+        this._delay = delay;
+    }
+
+    public call() {
+        window.clearTimeout(this.timer);
+        this.timer = window.setTimeout(() => {
+            this._func();
+        }, this._delay);
+    }
+}


### PR DESCRIPTION
Only run the linter when the editor is idle for more than `400ms`. This duration can (and probably should) be tweaked in `nodeview.ts:87`.

Executing the linting step too eagerly causes exceptions that slow down the editor enormously.

## Testing
Still requires some testing if this delay is good enough.