### PR TITLE
Fixed problems with text visibility when selected which happened for some themes (such as Light+ and the high contrast themes)

### DIFF
--- a/editor/src/kroqed-editor/codeview/coqTheme.json
+++ b/editor/src/kroqed-editor/codeview/coqTheme.json
@@ -27,8 +27,6 @@
 	},
   	".cm-cursor, .cm-dropCursor": {"borderLeftColor": "auto"},
 
-        "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {"backgroundColor": "var(--vscode-list-activeSelectionBackground)"},
-  
 	".cm-panels": {"backgroundColor": "var(--vscode-list-dropBackground)", "color": "var(--vscode-list-highlightForeground)"},
 	".cm-panels.cm-panels-top": {"borderBottom": "2px solid black"},
 	".cm-panels.cm-panels-bottom": {"borderTop": "2px solid black"},


### PR DESCRIPTION
The fix was simply to stop "forcing" the background color of the selection to be var(--vscode-list-activeSelectionBackground) and instead let the themes choose that themselves.