### PR TITLE
Add check for correctness of non input areas.

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,12 +277,17 @@
         }
       },
       {
-        "title": "Standard Coq Syntax",
+        "title": "Waterproof Use Case",
         "properties": {
           "waterproof.standardCoqSyntax": {
             "type": "boolean",
             "default": false,
             "description": "Enable Standard Coq syntax; if true, standard Coq syntax will be used instead of the Waterproof proof language."
+          }, 
+          "waterproof.enforceCorrectNonInputArea": {
+            "type": "boolean", 
+            "default": true, 
+            "description": "Enable correctness checks for non input areas. Will enforce that the content outside of an input area never changes!"
           }
         }
       },

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -12,6 +12,11 @@ export class WaterproofConfigHelper {
         return config().get<boolean>("teacherMode") as boolean;
     }
 
+    /** `waterproof.enforceCorrectNonInputArea` */
+    static get enforceCorrectNonInputArea() {
+        return config().get<boolean>("enforceCorrectNonInputArea") as boolean;
+    }
+
     /** `waterproof.standardCoqSyntax` */
     static get standardCoqSyntax() {
         return config().get<boolean>("standardCoqSyntax") as boolean;

--- a/src/pm-editor/file-utils.ts
+++ b/src/pm-editor/file-utils.ts
@@ -1,0 +1,65 @@
+import { window } from "vscode";
+
+export function getNonInputRegions(doc: string) {
+        
+    // get all input areas: 
+    const inputOpenTags = Array.from(doc.matchAll(/<input-area>/g));
+    const inputCloseTags = Array.from(doc.matchAll(/<\/input-area>/g));
+
+    const fromString = (input: string) => {
+        return input === "<input-area>" ? "open" : "close";
+    }
+
+    const allTags = [...inputOpenTags, ...inputCloseTags].map((value) => {
+        // open     -> consider position at the start of tag. 
+        // close    -> consider position at the end of tag.
+        const type = fromString(value[0]);
+        switch (type) {
+            case "open": 
+                return {position: value.index as number + value[0].length, type}
+            case "close": 
+                return {position: value.index as number, type}
+        }
+        
+
+    }).sort((a, b) => a.position - b.position);
+
+
+    const pairsCombined = Array.from(
+        {length:allTags.length/2}, 
+        (_,i) => {
+            const open = allTags[2*i];
+            const close = allTags[2*i + 1];
+            // const content = docOnDisk.substring(open.position, close.position);
+            return {open, close};
+        }
+    );
+
+
+    const outsideInputAreaRegions = Array.from({length: pairsCombined.length + 1}, (_, i) => {
+        if (i == 0) {
+            // special case
+            return { from: 0, to: pairsCombined[i].open.position }
+        } else if (i == pairsCombined.length) {
+            return { from: pairsCombined[i-1].close.position, to: doc.length }
+        } else {
+            return { from: pairsCombined[i-1].close.position, to: pairsCombined[i].open.position }
+        }
+    }).map(value => {
+        return {...value, content: doc.substring(value.from, value.to)}
+    });
+
+    return outsideInputAreaRegions;
+}
+
+const RESTORE = "Restore";
+
+export const showRestoreMessage = (cbOnRestore: () => void) => {
+    window.showErrorMessage("Waterproof: The content outside of the input areas changed, this is not supposed to happen! Click the button below to restore.", RESTORE).then(restoreHandler(cbOnRestore));
+}
+
+const restoreHandler = (cbOnRestore: () => void) => {
+    return (value: typeof RESTORE | undefined) => {
+        if (value == RESTORE) cbOnRestore();
+    }
+}

--- a/src/pm-editor/pmWebview.ts
+++ b/src/pm-editor/pmWebview.ts
@@ -6,7 +6,8 @@ import { getNonce } from "../util";
 import { WebviewEvents, WebviewState } from "../webviews/coqWebview";
 import { SequentialEditor } from "./edit";
 import {getFormatFromExtension } from "./fileUtils";
-import { readFile } from "fs";
+import { WaterproofConfigHelper } from "../helpers";
+import { getNonInputRegions, showRestoreMessage } from "./file-utils";
 
 export class ProseMirrorWebview extends EventEmitter {
     /** The webview panel of this ProseMirror instance */
@@ -26,6 +27,17 @@ export class ProseMirrorWebview extends EventEmitter {
 
     /** The latest linenumbers message */
     private _linenumber: LineNumber | undefined = undefined;
+
+    private _teacherMode: boolean;
+    private _enforceCorrectNonInputArea: boolean;
+    private _lastCorrectDocString: string;
+
+    /** These regions contain the strings that are outside of the <input-area> tags, but including the tags themselves */
+    private _nonInputRegions: {
+        to: number, 
+        from: number, 
+        content: string
+     }[];
 
     /**
      * Collection of messages that were sent before, and should be resent if the editor
@@ -51,6 +63,12 @@ export class ProseMirrorWebview extends EventEmitter {
         this._cachedMessages = new Map();
         this.initWebview(extensionUri);
         this._document = doc;
+
+        this._nonInputRegions = getNonInputRegions(doc.getText());
+
+        this._teacherMode = WaterproofConfigHelper.teacherMode;
+        this._enforceCorrectNonInputArea = WaterproofConfigHelper.enforceCorrectNonInputArea;
+        this._lastCorrectDocString = doc.getText();
     }
 
     /** Create a prosemirror webview */
@@ -119,10 +137,14 @@ export class ProseMirrorWebview extends EventEmitter {
             if (e.affectsConfiguration("waterproof.teacherMode")) {
                 this.updateTeacherMode();
             }
-        }));
 
-        this._disposables.push(workspace.onDidChangeConfiguration(e => {
-            this.updateSyntaxMode();
+            if (e.affectsConfiguration("waterproof.standardCoqSyntax")) {
+                this.updateSyntaxMode();
+            }
+
+            if (e.affectsConfiguration("waterproof.enforceCorrectNonInputArea")) {
+                this._enforceCorrectNonInputArea = WaterproofConfigHelper.enforceCorrectNonInputArea;
+            }
         }));
 
         this._disposables.push(this._panel.webview.onDidReceiveMessage((msg) => {
@@ -198,9 +220,11 @@ export class ProseMirrorWebview extends EventEmitter {
 
     /** Toggle the teacher mode */
     private updateTeacherMode() {
+        const mode = WaterproofConfigHelper.teacherMode;
+        this._teacherMode = mode;
         this.postMessage({
             type: MessageType.teacher,
-            body: workspace.getConfiguration("waterproof").get("teacherMode")
+            body: mode
         }, true);
     }
 
@@ -208,7 +232,7 @@ export class ProseMirrorWebview extends EventEmitter {
     private updateSyntaxMode() {
         this.postMessage({
             type: MessageType.syntax,
-            body: workspace.getConfiguration("waterproof").get("standardCoqSyntax")
+            body: WaterproofConfigHelper.standardCoqSyntax
         }, true);
     }
 
@@ -234,6 +258,22 @@ export class ProseMirrorWebview extends EventEmitter {
         }
     }
 
+    // Restore the document to the last correct state, that is, a state for which the content 
+    //  outside of the <input-area> tags is correct.
+    private restore() {
+        this._workspaceEditor.edit(edit => {
+            edit.replace(
+                this.document.uri,
+                new Range(this._document.positionAt(0), this.document.positionAt(this.document.getText().length)),
+                this._lastCorrectDocString
+            )
+        });
+        // We save the document and call sync webview to make sure that the editor is up to date
+        this.document.save().then(() => {
+            this.syncWebview();
+        });
+    }
+
     /** Handle a doc change sent from prosemirror */
     private handleChangeFromEditor(change: DocChange | WrappingDocChange) {
         this._workspaceEditor.edit(e => {
@@ -244,6 +284,28 @@ export class ProseMirrorWebview extends EventEmitter {
                 this.applyChangeToWorkspace(change, e);
             }
         });
+
+        // If we are in teacher mode or we don't want to check for non input region correctness we skip it.
+        if (!this._teacherMode && this._enforceCorrectNonInputArea) {
+            let foundDefect = false;
+            const nonInputRegions = getNonInputRegions(this._document.getText());
+            if (nonInputRegions.length !== this._nonInputRegions.length) { 
+                foundDefect = true;
+            } else {
+                for (let i = 0; i < this._nonInputRegions.length; i++) {
+                    if (this._nonInputRegions[i].content !== nonInputRegions[i].content) {
+                        foundDefect = true;
+                        break;
+                    }
+                }
+            }
+
+            if (foundDefect) { 
+                showRestoreMessage(this.restore.bind(this));
+            } else {
+                this._lastCorrectDocString = this._document.getText();
+            }
+        }
     }
 
     /** Handle the messages received from prosemirror */


### PR DESCRIPTION
# Features
- On every edit we compare the contents of the input areas currently in the document to the content of the input areas when the editor was opened.
- This can be turned off by setting `waterproof.enforceCorrectNonInputArea` to false in settings, in the case that it has a big hit on performance for some machine.
- When we encounter content outside of the input area that has been changed, we
    1. Show a notification in the bottom right corner informing the user about the change.
    2. We allow the user to press a "Restore" button, which will restore the document (the whole document, not just the content outside of the input areas) to a state that does not have the 'defect'.
    3. The restore point is not updated when we have encountered a 'defect' in the file.

# How to test
Currently I don't know of a way on `main` to edit content outside of an input area :).

One way to test is to disable the fix for the `ctrl-space` bug, which can be done by commenting out the
[dispatch function in nodeview.ts:89](https://github.com/impermeable/waterproof-vscode/blob/b8120edf7ed97e41de6b294b521dd4816eeb7796/editor/src/kroqed-editor/codeview/nodeview.ts#L89) (up to and including line 119). This allows autocompletion in a non-input-area by using `ctrl-space` and clicking one of the options.

## TODO/FIXME
Currently the check works only after two edits. Example: 
1. The content outside of an input area gets changed, for instance by using `ctrl-space` and autocompleting there.
2. No notification is shown yet.
3. The user edits an input-area.
4. The notification is shown.
5. The restore point button is pressed -> will restore the edit from 1. **and** the edit from 3.
