### PR TITLE
added check for periods in expand definition

### DIFF
--- a/views/commonExecute/commonExecute.tsx
+++ b/views/commonExecute/commonExecute.tsx
@@ -133,7 +133,9 @@ export function CommonExecute() {
     //button press execute
     const handleExecute = () => {
         //Send the message the execute button was pressed
-        vscode.postMessage({time: date.getTime(), type: MessageType.command, body: `_internal_ Expand the definition of ${inputText1} in (${inputText2}).`})
+        vscode.postMessage({time: date.getTime(), 
+                            type: MessageType.command, 
+                            body: `_internal_ Expand the definition of ${inputText1} in (${inputText2.replace(/\.\s*$/, '')}).`})
         setIsLoading(true);
     };
 


### PR DESCRIPTION
Whenever the given input ends with a period followed by 0 or more spaces, we disregard them. This only happens if the sentence ends with that combination, so a period in the middle of the sentence is not removed.