### PR TITLE
Fix goal panel showing too much information

### DIFF
--- a/editor/src/kroqed-editor/mappingModel vFiles/helper-functions.ts
+++ b/editor/src/kroqed-editor/mappingModel vFiles/helper-functions.ts
@@ -1,0 +1,88 @@
+import { Fragment } from "prosemirror-model";
+import { OperationType, textEndHTML, textStartHTML } from "./types";
+import { ReplaceStep } from "prosemirror-transform";
+
+
+//// We define helper functions used by the vscode mapping 
+
+/** A helper function to get the in text representation (in vscode doc) of a ending tag */
+export function getEndHtmlTagText(tagId: string | undefined) : string {
+    if (tagId === undefined) throw new Error("In the vscode Mapping, a tag was undefined ");
+    let result : string | undefined =  textEndHTML.get(tagId);
+    if (result === undefined) throw new Error("In the vscode Mapping, a tag, " + tagId + ", was processed that should not be processed");
+    return result;
+}
+
+/** A helper function to get the in text representation (in vscode doc) of a starting tag */
+export function getStartHtmlTagText(tagId: string | undefined) : string {
+    if (tagId === undefined) throw new Error("In the vscode Mapping, a tag was undefined ");
+    let result : string | undefined = textStartHTML.get(tagId);
+    if (result === undefined) throw new Error("In the vscode Mapping, a tag, " + tagId + ", was processed that should not be processed");
+    return result;
+}
+
+/** Used to parse a prosemirror fragment into a form that can be used to update the mapping */
+export function parseFragment(frag: Fragment | undefined) : {proseOffset: number, starttext: string, endtext: string, tags: Array<string>, stringCell: boolean} {
+    // Error checking
+    if (frag === undefined) throw new Error("Received an undfined fragment during parsing of fragment for vscode mapping");
+    if (frag.childCount > 1) throw new Error("Fragment contains more children than expected");
+
+    // Base case
+    if (frag.childCount == 0) return {proseOffset: 0, starttext: "", endtext: "", tags: [], stringCell: false};
+
+    /** Recursively get the fragment information for inner child */
+    let inside = parseFragment(frag.firstChild?.content);
+
+    let end = getEndHtmlTagText(frag.firstChild?.type.name);
+    let start = getStartHtmlTagText(frag.firstChild?.type.name);
+
+    /** Does the inner most cell of this fragment support text edits */
+    let needsCell: boolean = false;
+
+    /** Add newlines to end and start of new tags */
+    switch(frag.firstChild?.type.name) {
+        case "coqblock": 
+            start = "\n" + start + "\n";
+            end = "\n" + end + "\n";
+            break;
+        case "coqdoc":
+            start = "\n" + start;
+            end = end + "\n";
+            break;
+        case "math_display":
+            start += "$";
+            end += "$";
+        case "coqcode": case "coqdown":
+        case "markdown":
+            needsCell = true;
+            break;
+        default:
+            break;
+    }
+
+    // Create an array of tags
+    let newTags = new Array<string>();
+    if(frag.firstChild?.type.name !== "text") newTags.push(start); 
+    newTags = newTags.concat(inside.tags); 
+    if(frag.firstChild?.type.name !== "text") newTags.push(end);
+
+    return {
+        endtext: inside.endtext + end,
+        starttext: start + inside.starttext,
+        proseOffset: inside.proseOffset + ((frag.firstChild?.type.name == "text") ? 0 : 2),
+        tags: newTags,
+        stringCell: inside.stringCell || needsCell,
+    };
+}
+
+/** This gets the offset in the vscode document that is being added (then >0) or removed (then <0) */
+export function getTextOffset(type: OperationType, step: ReplaceStep) : number  {
+    if (type == OperationType.delete) return step.from - step.to;
+
+    /** Validate step if not a delete type */
+    if (step.slice.content.firstChild === null || step.slice.content.firstChild.text === undefined) throw new Error(" Invalid replace step " + step);
+
+    if (type == OperationType.insert) return step.slice.content.firstChild.text?.length;
+
+    return step.slice.content.firstChild.text?.length + step.from - step.to;
+}

--- a/editor/src/kroqed-editor/mappingModel vFiles/index.ts
+++ b/editor/src/kroqed-editor/mappingModel vFiles/index.ts
@@ -1,0 +1,2 @@
+// Export the mapping
+export { TextDocMapping } from "./vscodeMapping";

--- a/editor/src/kroqed-editor/mappingModel vFiles/nodeUpdate.ts
+++ b/editor/src/kroqed-editor/mappingModel vFiles/nodeUpdate.ts
@@ -1,0 +1,405 @@
+import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
+import { DocChange, WrappingDocChange } from "../../../../shared";
+import { HtmlTagInfo, OperationType, ParsedStep, StringCell } from "./types";
+import { getEndHtmlTagText, getStartHtmlTagText, getTextOffset, parseFragment } from "./helper-functions";
+
+
+
+export class NodeUpdate {
+
+    /** Used to parse a step that causes nodes to be updated instead of just text */
+    static nodeUpdate(step: ReplaceStep | ReplaceAroundStep, stringBlocks: Map<number,StringCell>, endHtmlMap: Map<number,HtmlTagInfo>, startHtmlMap: Map<number,HtmlTagInfo>) : ParsedStep {
+        let result : ParsedStep;
+
+        /** Get the doc change and do some error checking */
+        if (step instanceof ReplaceStep) {
+            // Determine operation type
+            let type: OperationType = OperationType.delete;
+            if (step.from == step.to) type = OperationType.insert;
+
+            // We only support pure insertions and deletions
+            if (type == OperationType.delete && step.slice.content.firstChild !== null) throw new Error(" We support ReplaceStep for nodes, but, only, as pure insertions and deletions ");
+
+            // Check that the slice conforms to our assumptions
+            if (step.slice.openStart != 0 || step.slice.openEnd != 0) throw new Error(" We do not support partial slices for ReplaceSteps");
+
+            if (type === OperationType.delete) {
+                // Is the node deletion in a valid location
+                if(!startHtmlMap.has(step.from) || !endHtmlMap.has(step.to) ) throw new Error(" Mapping does not contain this position, is node inserted in middle of another node?");
+                result = NodeUpdate.replaceStepDelete(step,stringBlocks,endHtmlMap,startHtmlMap);
+            } else {
+                result = NodeUpdate.replaceStepInsert(step,stringBlocks,endHtmlMap,startHtmlMap);
+            }
+
+        } else {
+            // Replace around step in valid form
+            if (step.gapFrom - step.from > 1 || step.to - step.gapTo > 1) throw new Error(" We only support ReplaceAroundSteps with a single gap");
+
+            // Deletion ReplaceAroundstep
+            if (step.slice.content.firstChild == null) {
+                // Error check Deletion step
+                if (!startHtmlMap.has(step.from) || !endHtmlMap.has(step.gapFrom)) throw new Error(" ReplaceAroundStep deletion is in unconventional form");
+                if (!startHtmlMap.has(step.gapTo) || !endHtmlMap.has(step.to)) throw new Error(" ReplaceAroundStep deletion is in unconventional form");
+
+                result = NodeUpdate.replaceAroundStepDelete(step,stringBlocks,endHtmlMap,startHtmlMap);
+            } else if (step.slice.content.childCount == 1 && step.slice.openStart == 0 && step.slice.openEnd == 0) {
+                // Error check ReplaceAroundStep insertion
+                if (step.gapFrom - step.from > 0 || step.to - step.gapTo > 0 || step.insert != 1) throw new Error(" We only support ReplaceAroundStep that inserts chunk in single node");
+                if (!(startHtmlMap.has(step.from) || endHtmlMap.has(step.to))) throw new Error(" Not a proper wrapping ");
+                if(!(step.slice.content.firstChild.type.name == 'hint' || step.slice.content.firstChild.type.name == 'input')) throw new Error(" We only support wrapping in hints or inputs ");
+
+                result = NodeUpdate.replaceAroundStepInsert(step,stringBlocks,endHtmlMap,startHtmlMap);
+            } else {
+                throw new Error(" We do not support this type of ReplaceAroundStep");
+            }
+            
+        }
+
+        return result;        
+    }
+
+    private static replaceStepDelete(step: ReplaceStep, stringBlocks: Map<number,StringCell>, endHtmlMap: Map<number,HtmlTagInfo>, startHtmlMap: Map<number,HtmlTagInfo>) : ParsedStep {
+        //// Determine the in text document change vscode side
+
+        /** The resulting change of this step operation */
+        let result : DocChange = {
+            startInFile: 0,
+            endInFile: 0,
+            finalText: ""
+        }
+
+        /** Get the starting and end tag of the block deletion */
+        let startTag: HtmlTagInfo | undefined = startHtmlMap.get(step.from);
+        let endTag: HtmlTagInfo | undefined = endHtmlMap.get(step.to);
+        if (startTag === undefined || endTag === undefined ) throw new Error("The deleted block was not in the mapping");
+
+        /** Determine the resulting DocChange indices */
+        result.startInFile = startTag.offsetText;
+        result.endInFile = endTag.offsetText;
+
+        //// Update the mapping to reflect the new prosemirror state
+
+        // New maps
+        let newHtmlMap = new Map<number,HtmlTagInfo>();
+        let newHtmlMapS = new Map<number,HtmlTagInfo>();
+        let newMap = new Map<number,StringCell>();
+
+        // The offsets that were deleted from the doc needed to update the mappings
+        let proseOffset = getTextOffset(OperationType.delete,step);
+        // This has an additional costs, which are taken account in the suceeding loop
+        let textOffset = proseOffset;
+
+
+        for (let [key, value] of endHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key > step.from) {
+                if (key <= step.to) { // This block has been removed
+                    // Adjust textOffset based on what has been deleted
+                    textOffset += 1 - value.textCost;
+                    continue;
+                } 
+                newkey += proseOffset; newvalue.offsetText += textOffset;
+                newvalue.offsetProse += proseOffset;
+            }
+            newHtmlMap.set(newkey,newvalue);
+        }
+
+
+        for (let [key, value] of startHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= step.from) {
+                if (key < step.to) continue; // This block has been removed
+                newkey += proseOffset; newvalue.offsetText += textOffset;
+                newvalue.offsetProse += proseOffset;
+            }
+            newHtmlMapS.set(newkey,newvalue);
+        }
+
+        
+        for(let [key,value] of stringBlocks) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= step.from) {
+                if (key < step.to) continue; // This block has been removed
+                newvalue.startProse += proseOffset;
+                newkey += proseOffset;
+                newvalue.startText += textOffset;
+                newvalue.endProse += proseOffset;
+                newvalue.endText += textOffset;
+            }
+            newMap.set(newkey,newvalue);
+        }
+
+        return {result, newHtmlMapS, newHtmlMap, newMap};
+    }
+
+    /** Converts a replace step that is a pure node update to a DocChange */
+    private static replaceStepInsert(step: ReplaceStep, stringBlocks: Map<number,StringCell>, endHtmlMap: Map<number,HtmlTagInfo>, startHtmlMap: Map<number,HtmlTagInfo>) : ParsedStep {
+        let result : DocChange = {
+            startInFile: 0,
+            endInFile: 0,
+            finalText: ""
+        }
+
+        let newMap = new Map<number,StringCell>();
+        let newHtmlMap = new Map<number,HtmlTagInfo>();
+        let newHtmlMapS = new Map<number,HtmlTagInfo>();
+        let final;
+        let inBetweenText: string = "";
+        let textIndex: number = 0;
+
+        // Check if we are in an empty document
+        if (endHtmlMap.size == 0) {
+            final = parseFragment(step.slice.content);
+            if (step.slice.content.firstChild!.content.firstChild !== null) inBetweenText = step.slice.content.firstChild!.content.firstChild.textContent;
+
+            /** Compute the resulting DocChange */
+            result.startInFile = 0;
+            result.endInFile = 0;
+            result.finalText = final.starttext + inBetweenText + final.endtext;
+        } else {
+            // Check whether we know of the insertion location 
+            if (!(startHtmlMap.has(step.from) || endHtmlMap.has(step.from))) throw new Error(" The insertion spot was not recognized, either mapping is off or a bug in code");
+
+            let location = startHtmlMap.has(step.from) ? startHtmlMap.get(step.from) : endHtmlMap.get(step.from);
+
+            if (location === undefined) throw new Error(" This cannot happen... ");
+
+             /** Compute the resulting DocChange */
+            result.startInFile = location?.offsetText;
+            result.endInFile = location?.offsetText;
+            final = parseFragment(step.slice.content);
+            result.finalText = final.starttext + final.endtext;
+
+
+            //// Update the existing mapping
+
+
+            for(let [key,value] of stringBlocks) {
+                let newkey = key; let newvalue = structuredClone(value);
+                if (key >= step.from) {
+                    newvalue.startProse += final.proseOffset;
+                    newkey += final.proseOffset;
+                    newvalue.startText += result.finalText.length;
+                    newvalue.endProse += final.proseOffset;
+                    newvalue.endText += result.finalText.length;
+                }
+                newMap.set(newkey,newvalue);
+            }
+
+            for (let [key, value] of endHtmlMap) {
+                let newkey = key; let newvalue = structuredClone(value);
+                if (key > step.from) {
+                    newkey += final.proseOffset; newvalue.offsetText += result.finalText.length;
+                    newvalue.offsetProse += final.proseOffset;
+                }
+                newHtmlMap.set(newkey,newvalue);
+            }
+            for (let [key, value] of startHtmlMap) {
+                let newkey = key; let newvalue = structuredClone(value);
+                if (key >= step.from) {
+                    newkey += final.proseOffset; newvalue.offsetText += result.finalText.length;
+                    newvalue.offsetProse += final.proseOffset;
+                }
+                newHtmlMapS.set(newkey,newvalue);
+            }
+
+            /** Set the location of where the edit is being made in vscode doc */
+            textIndex = location.offsetText;
+        }
+
+        // Add the new cell to stringBlocks map, if a text area was inserted
+        if (final.stringCell) {
+            const newIndex = step.from + final.proseOffset / 2;
+            // Add the new string cell
+            newMap.set(newIndex, {
+                startProse: newIndex,
+                endProse: newIndex + result.finalText.length,
+                startText: textIndex + final.starttext.length,
+                endText: textIndex + final.starttext.length + inBetweenText.length,
+            });
+        }
+        
+        let proseIndex = step.from;
+        // Add new tags
+        for (let i = 0; i < final.tags.length; i++) {
+            if (i == final.tags.length/2) {
+                proseIndex += inBetweenText.length;
+                textIndex += inBetweenText.length;
+            }
+            newHtmlMapS.set(proseIndex,{ offsetProse: proseIndex, offsetText: textIndex, textCost: final.tags[i].length});
+            textIndex += final.tags[i].length;
+            proseIndex += 1;
+            newHtmlMap.set(proseIndex,{ offsetProse: proseIndex, offsetText: textIndex, textCost: final.tags[i].length});
+        }
+        // Sort the maps, so they are increasing in keys
+        newMap = new Map([...newMap.entries()].sort((a,b) => a[0] - b[0]));
+        newHtmlMap = new Map([...newHtmlMap.entries()].sort((a,b) => a[0] - b[0]));
+        newHtmlMapS = new Map([...newHtmlMapS.entries()].sort((a,b) => a[0] - b[0]));
+
+        return {result, newHtmlMapS, newHtmlMap, newMap};
+    }
+
+    /** Setups the wrapping doc change for the suceeding functions */
+    private static setupWrapper() : WrappingDocChange {
+        let edit1: DocChange = {
+            startInFile: 0,
+            endInFile: 0,
+            finalText: ""
+        }; 
+        let edit2: DocChange = {
+            startInFile: 0,
+            endInFile: 0,
+            finalText: ""
+        };
+
+        /** The resulting document change to document model */
+        let result: WrappingDocChange = {
+            firstEdit: edit1,
+            secondEdit: edit2
+        }; 
+        return result;
+    }
+
+    private static replaceAroundStepDelete(step: ReplaceAroundStep, stringBlocks: Map<number,StringCell>, endHtmlMap: Map<number,HtmlTagInfo>, startHtmlMap: Map<number,HtmlTagInfo>) : ParsedStep {
+        let result : WrappingDocChange = NodeUpdate.setupWrapper();
+
+        // Update maps
+        let newHtmlMap = new Map<number,HtmlTagInfo>();
+        let newHtmlMapS = new Map<number,HtmlTagInfo>();
+        let newMap = new Map<number,StringCell>();
+
+        // @ts-ignore
+        result.firstEdit.startInFile = startHtmlMap.get(step.from)?.offsetText;
+        //@ts-ignore
+        result.firstEdit.endInFile = endHtmlMap.get(step.gapFrom)?.offsetText;
+        
+        // @ts-ignore
+        result.secondEdit.startInFile = startHtmlMap.get(step.gapTo)?.offsetText;
+        //@ts-ignore
+        result.secondEdit.endInFile = endHtmlMap.get(step.to)?.offsetText;
+
+        for (let [key, value] of endHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key == step.gapFrom || key == step.to) continue;
+            if (key >= step.gapFrom && key >= step.to) { 
+                //@ts-ignore
+                newkey -= 2; newvalue.offsetText -= (endHtmlMap.get(step.to)?.textCost + endHtmlMap.get(step.gapFrom)?.textCost);
+                newvalue.offsetProse -= 2;
+            } else if(key >= step.gapFrom) {
+                //@ts-ignore
+                newkey -= 1; newvalue.offsetText -= endHtmlMap.get(step.gapFrom)?.textCost;
+                newvalue.offsetProse -= 1;
+            }
+            newHtmlMap.set(newkey,newvalue);
+        }
+        for (let [key, value] of startHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key == step.from || key == step.gapTo) continue;
+            if (key >= step.from && key >= step.gapTo) {
+                //@ts-ignore
+                newkey -= 2; newvalue.offsetText -= (startHtmlMap.get(step.from)?.textCost + startHtmlMap.get(step.gapTo)?.textCost);
+                newvalue.offsetProse -= 2;
+            } else if(key >= step.from) {
+                //@ts-ignore
+                newkey -= 1; newvalue.offsetText -= startHtmlMap.get(step.from)?.textCost;
+                newvalue.offsetProse -= 1;
+            }
+            newHtmlMapS.set(newkey,newvalue);
+        }
+
+        for(let [key,value] of stringBlocks) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= step.gapFrom && key >= step.to) {
+                newvalue.startProse -= 2; newkey -= 2;  newvalue.endProse -= 2;
+                //@ts-ignore
+                newvalue.startText -= (endHtmlMap.get(step.to)?.textCost + endHtmlMap.get(step.gapFrom)?.textCost); 
+                //@ts-ignore
+                newvalue.endText -= (endHtmlMap.get(step.to)?.textCost + endHtmlMap.get(step.gapFrom)?.textCost);
+            } else if (key >= step.gapFrom) {
+                newvalue.startProse -= 1; newkey -= 1;  newvalue.endProse -= 1;
+                //@ts-ignore
+                newvalue.startText -= endHtmlMap.get(step.gapFrom)?.textCost; 
+                //@ts-ignore
+                newvalue.endText -= endHtmlMap.get(step.gapFrom)?.textCost;
+            }
+            newMap.set(newkey,newvalue);
+        }
+
+        return {result, newHtmlMapS, newHtmlMap, newMap};
+    }
+
+
+    private static replaceAroundStepInsert(step: ReplaceAroundStep, stringBlocks: Map<number,StringCell>, endHtmlMap: Map<number,HtmlTagInfo>, startHtmlMap: Map<number,HtmlTagInfo>) : ParsedStep {
+        let result : WrappingDocChange = NodeUpdate.setupWrapper();
+
+        // Update maps
+        let newHtmlMap = new Map<number,HtmlTagInfo>();
+        let newHtmlMapS = new Map<number,HtmlTagInfo>();
+        let newMap = new Map<number,StringCell>();
+
+        result.firstEdit.startInFile = startHtmlMap.get(step.from)!.offsetText;
+        result.firstEdit.endInFile = result.firstEdit.startInFile;
+
+        result.secondEdit.startInFile = endHtmlMap.get(step.to)!.offsetText;
+        result.secondEdit.endInFile = result.secondEdit.startInFile;
+    
+        if (step.slice.content.firstChild!.type.name == 'hint') {
+            result.firstEdit.finalText = '<hint title="💡 Hint">';
+            result.secondEdit.finalText = '</hint>'
+        } else {
+            result.firstEdit.finalText =  getStartHtmlTagText(step.slice.content.firstChild!.type.name);
+            result.secondEdit.finalText =  getEndHtmlTagText(step.slice.content.firstChild!.type.name);
+        }
+
+        //// Update mappings
+
+        for (let [key, value] of endHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key - 1 >= step.from && key - 1 >= step.to) { 
+                newkey += 2; newvalue.offsetText += result.firstEdit.finalText.length + result.secondEdit.finalText.length;
+                newvalue.offsetProse += 2;
+            } else if(key - 1 >= step.from) {
+                newkey += 1; newvalue.offsetText += result.firstEdit.finalText.length;
+                newvalue.offsetProse += 1;
+            }
+            newHtmlMap.set(newkey,newvalue);
+        }
+        for (let [key, value] of startHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= step.from && key >= step.to) {
+                newkey += 2; newvalue.offsetText += result.firstEdit.finalText.length + result.secondEdit.finalText.length;
+                newvalue.offsetProse += 2;
+            } else if(key >= step.from) {
+                newkey += 1; newvalue.offsetText += result.firstEdit.finalText.length;
+                newvalue.offsetProse += 1;
+            }
+            newHtmlMapS.set(newkey,newvalue);
+        }
+
+        for(let [key,value] of stringBlocks) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= step.from && key >= step.to) {
+                newvalue.startProse += 2; newkey += 2;  newvalue.endProse += 2;
+                newvalue.startText += result.firstEdit.finalText.length + result.secondEdit.finalText.length;
+                newvalue.endText += result.firstEdit.finalText.length + result.secondEdit.finalText.length;
+            } else if (key >= step.from) {
+                newvalue.startProse += 1; newkey += 1;  newvalue.endProse += 1;
+                newvalue.startText += result.firstEdit.finalText.length;
+                newvalue.endText += result.firstEdit.finalText.length;
+            }
+            newMap.set(newkey,newvalue);
+        }
+
+        // Add the new html tags
+        newHtmlMapS.set(step.from,{offsetProse: step.from, offsetText: result.firstEdit.startInFile, textCost: result.firstEdit.finalText.length});
+        newHtmlMapS.set(step.to + 1,{offsetProse: step.to, offsetText: result.secondEdit.startInFile + result.firstEdit.finalText.length, textCost: result.secondEdit.finalText.length});
+        newHtmlMap.set(step.from + 1,{offsetProse: step.from + 2, offsetText: result.firstEdit.startInFile + result.firstEdit.finalText.length, textCost: result.firstEdit.finalText.length});
+        newHtmlMap.set(step.to + 2,{offsetProse: step.to + 2, offsetText: result.secondEdit.startInFile + result.firstEdit.finalText.length + result.secondEdit.finalText.length, textCost: result.secondEdit.finalText.length});
+
+        newHtmlMap = new Map([...newHtmlMap.entries()].sort((a,b) => a[0] - b[0]));
+        newHtmlMapS = new Map([...newHtmlMapS.entries()].sort((a,b) => a[0] - b[0]));
+
+        return {result, newHtmlMapS, newHtmlMap, newMap};
+    }
+} 
+ 

--- a/editor/src/kroqed-editor/mappingModel vFiles/textUpdate.ts
+++ b/editor/src/kroqed-editor/mappingModel vFiles/textUpdate.ts
@@ -1,0 +1,99 @@
+import { ReplaceStep } from "prosemirror-transform";
+import { DocChange } from "../../../../shared";
+import { HtmlTagInfo, OperationType, ParsedStep, StringCell } from "./types";
+import { getTextOffset } from "./helper-functions";
+
+
+
+export class TextUpdate {
+
+    /** This function is responsible for handling updates in prosemirror that happen exclusively as text edits and translating them to vscode text doc */
+    static textUpdate(step: ReplaceStep, stringBlocks: Map<number,StringCell>, endHtmlMap: Map<number,HtmlTagInfo>, startHtmlMap: Map<number,HtmlTagInfo>) : ParsedStep {
+        // Determine operation type
+        let type: OperationType = OperationType.replace;
+        if (step.from == step.to) type = OperationType.insert;
+        if (step.slice.content.firstChild === null) type = OperationType.delete;
+
+        // If there is more than one node in the fragment of step, throw an error
+        if(step.slice.content.childCount > 1) throw new Error(" Text edit contained more text nodes than expected ");
+
+        // Check that the slice conforms to our assumptions
+        if (step.slice.openStart != 0 || step.slice.openEnd != 0) throw new Error(" We do not support partial slices for ReplaceSteps");
+
+        // Find correct stringCell in which this step takes place
+
+        /** Key of the stringCell in which step occurs */
+        let correctCellKey = 0;
+
+        for (let [key,value] of stringBlocks) {
+            if (key > step.from) break;
+            correctCellKey = key;
+        }
+
+        /** Get the target cell */
+        let targetCell: StringCell | undefined = stringBlocks.get(correctCellKey);
+        if (targetCell === undefined) throw new Error(" Target cell is not in mapping!!! ");
+
+        /** Check that the change is, indeed, happening within a stringcell */
+        if (targetCell.endProse < step.from) throw new Error(" Step does not happen within cell ");
+
+        /** The offset within the correct stringCell for the step action */ 
+        let offsetBegin = step.from - targetCell.startProse;
+
+        /** The offset within the correct stringCell for the step action */ 
+        let offsetEnd = step.to - targetCell.startProse;  
+
+        let text = step.slice.content.firstChild && step.slice.content.firstChild.text ? step.slice.content.firstChild.text : "";
+
+        /** The resulting document change to document model */
+        let result: DocChange = {
+            startInFile: targetCell.startText + offsetBegin,
+            endInFile: targetCell.startText + offsetEnd,
+            finalText: text
+        }
+
+        //// Find updated mappings
+
+        // Update the mapping to reflect change
+        let newMap = new Map<number,StringCell>();
+        let offset = getTextOffset(type,step);
+        // Loop through all the stringblocks
+        for(let [key,value] of stringBlocks) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= correctCellKey) {
+                if (key != correctCellKey) {
+                    newvalue.startProse += offset;
+                    newkey += offset;
+                    newvalue.startText += offset;
+                }
+                newvalue.endProse += offset;
+                newvalue.endText += offset;
+            }
+            newMap.set(newkey,newvalue);
+        }
+        
+
+        let newHtmlMap = new Map<number,HtmlTagInfo>();
+        let newHtmlMapS = new Map<number,HtmlTagInfo>();
+        for (let [key, value] of endHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key > step.from) {
+                if (key <= step.to) throw new Error(" Edit did not take place in string cell ");
+                newkey += offset; newvalue.offsetProse += offset;
+                newvalue.offsetText += offset;
+            }
+            newHtmlMap.set(newkey,newvalue);
+        }
+        
+        for (let [key, value] of startHtmlMap) {
+            let newkey = key; let newvalue = structuredClone(value);
+            if (key >= step.to) {
+                newkey += offset; newvalue.offsetProse += offset;
+                newvalue.offsetText += offset;
+            }
+            newHtmlMapS.set(newkey,newvalue);
+        }
+
+        return {result, newHtmlMapS, newHtmlMap, newMap};
+    }
+}

--- a/editor/src/kroqed-editor/mappingModel vFiles/types.ts
+++ b/editor/src/kroqed-editor/mappingModel vFiles/types.ts
@@ -1,0 +1,72 @@
+import { DocChange, WrappingDocChange } from "../../../../shared";
+
+//// The types used by this module
+
+/**
+ * In prosemirror, every step is a replace step. This enum is used to classify 
+ * the steps into the given 'pure' operations
+ */
+export enum OperationType {
+    insert = "insert",
+    delete = "delete",
+    replace = "replace"
+};
+
+/**
+ * The type returned by the functions converting steps to Document Changes of the
+ * underlying vscode model of the document
+ */
+export type ParsedStep = {
+    /** The document change that will be forwarded to vscode */
+    result: DocChange | WrappingDocChange;
+    /** The new map mapping starting positions of HtmlTags in prosemirror */
+    newHtmlMapS: Map<number,HtmlTagInfo>;
+    /** The new map mapping ending positions of HtmlTags in prosemirror */
+    newHtmlMap: Map<number,HtmlTagInfo>;
+    /** The new map of stringBlocks */
+    newMap: Map<number,StringCell>;
+}
+
+
+
+/**
+ * Represents an area of text, that is editable in the prosemirror view and its
+ * mapping to the vscode document
+ */
+export type StringCell = { 
+    /** The prosemirror starting index of this cell */
+    startProse: number,
+    /** The prosemirror ending index of this cell */
+    endProse: number,
+    /** The starting index of this cell in the text document string vscode side */
+    startText: number,
+    /** The ending index of this cell in the text document string vscode side */
+    endText: number,
+};
+
+
+/**
+ * Represents the details of a tags starting or ending position needed
+ * to map it correctly from prosemirror to the vscode text document
+ */
+export type HtmlTagInfo = {
+    /** The index within the text document string vscode side */
+    offsetText: number,
+    /** The prosemirror index */
+    offsetProse: number,
+    /** The length of text this tag represents in vscode */ 
+    textCost: number,
+};
+
+//// Some static data structures needed for the mapping
+
+
+
+/** This stores the characters that each 'starting' HTML tag represents in the orginal document */                                               
+export const textStartHTML: Map<string, string> = new Map<string, string>([["coqcode", ""], ["coqdoc", "(** "], ["coqdown", ""], ["math-display", "$"], ["input-area","(* input *)"],["text",""]]);
+    
+/** This stores the characters that each 'ending' HTML tag represents the orginal document */
+export const textEndHTML: Map<string, string> = new Map<string, string>([["coqcode", ""], ["coqdoc", "*)"], ["coqdown", ""], ["math-display", "$"], ["input-area","(* /input-area *)"], ["hint", "(* /hint *)"], ["text",""]]);
+
+// Note the hint tag represents an edge case, as it has dynamic test depending on its name
+// Note math-display is represented with '$', however this is only true in coqdoc... The mapping makes sure to include '$$' if in standard markdown

--- a/editor/src/kroqed-editor/mappingModel vFiles/vscodeMapping.ts
+++ b/editor/src/kroqed-editor/mappingModel vFiles/vscodeMapping.ts
@@ -1,0 +1,384 @@
+import { Step, ReplaceStep, ReplaceAroundStep } from "prosemirror-transform";
+import { DocChange, WrappingDocChange } from "../../../../shared";
+import { getEndHtmlTagText, getStartHtmlTagText} from "./helper-functions";
+import { StringCell, HtmlTagInfo, ParsedStep} from "./types";
+import { TextUpdate } from "./textUpdate";
+import { NodeUpdate } from "./nodeUpdate";
+
+
+/**
+ * A type to specify an HTML tag in the prosemirror content elem.
+ */
+interface TagInformation {
+    /** The starting index of the tag in the input string */
+    start: number; 
+    /** The ending index of the tag in the input string */
+    end: number;
+    /** The number of 'hidden' newlines the starting tag encodes in the original vscode document */
+    preNumber: number;
+    /** The number of 'hidden' newlines the ending tag encodes in the original vscode document */
+    postNumber: number;
+    /** The actual tag */
+    content: string;
+};
+
+
+/**
+ * We will preface this class with saying that this is most probably not 'the' smart approach. In fact,
+ * it could possibly be simpler to do all this with the EditorState document node (textContent attribute).
+ * However, we had thought this approach would be somewhat viable and nice for large documents, as you are not
+ * sending the entire doc back and forth, but it comes at the cost of complexity.
+ * 
+ * This class is responsible for keeping track of the mapping between the prosemirror state and the vscode Text
+ * Document model
+ */
+export class TextDocMapping {
+    /** This stores the String cells of the entire document */
+    private stringBlocks: Map<number, StringCell>;
+    /** This stores the inverted mapping of stringBlocks  */
+    private invStringBlocks: Map<number, StringCell>;
+    /** This maps the AFTER prosemirror positions of all the HTML tags to positions in the textdocument */
+    private endHtmlMap: Map<number, HtmlTagInfo>;
+    /** This maps the BEFORE prosemirror positions of all the HTML tags to positions in the textdocument */
+    private startHtmlMap: Map<number, HtmlTagInfo>;
+    /** The version of the underlying textDocument */
+    private _version: number;
+
+    /** The different possible HTMLtags in kroqed-schema */
+    private static HTMLtags: Set<string> = new Set<string>([
+        "markdown",
+        "input-area",
+        "coqblock",
+        "coqcode",
+        "coqdoc",
+        "math-display",
+        "hint",
+        "coqdown",
+    ]);
+
+    /** 
+     * Constructs a prosemirror view vsode mapping for the inputted prosemirror html elem
+     * 
+     * @param inputString a string contatining the prosemirror content html elem
+     */
+    constructor(inputString: string, versionNum: number) {
+        this._version = versionNum;
+        this.stringBlocks = new Map<number, StringCell>();
+        this.endHtmlMap = new Map<number,HtmlTagInfo>();
+        this.startHtmlMap = new Map<number,HtmlTagInfo>();
+        this.initialize(inputString);
+    }
+
+    //// The getters of this class
+
+    /**
+     * Returns the mapping to preserve integrity
+     */
+    public getMapping() {
+        return this.stringBlocks
+    }
+
+    /**
+     * Get the version of the underlying text document
+     */
+    public get version() {
+        return this._version;
+    }
+
+    /** Returns the vscode document model index of prosemirror index */
+    public findPosition(index: number) {
+        let correctCellKey = 0;
+        for (let [key,value] of this.stringBlocks) {
+            if (key > index) break;
+            correctCellKey = key;
+        }
+        let targetCell: StringCell | undefined = this.stringBlocks.get(correctCellKey);
+        if (targetCell === undefined) throw new Error(" The vscode document model index could not be found ");
+        return (index - correctCellKey) + targetCell.startText;
+    }
+
+    /** Returns the prosemirror index of vscode document model index */
+    public findInvPosition(index: number) {
+        let correctCellKey = 0;
+        for (let [key,value] of this.invStringBlocks) {
+            if (key > index) break;
+            correctCellKey = key;
+        }
+        let targetCell: StringCell | undefined = this.invStringBlocks.get(correctCellKey);
+        if (targetCell === undefined) throw new Error(" The prosemirror index could not be found ");
+        return (index - correctCellKey) + targetCell.startProse;
+    }
+
+    //// The methods used to manage the mapping
+
+    /**
+     * Initializes the mapping according to the inputed html content elem
+     * 
+     * @param inputString the string of the html elem
+     */
+    private initialize(inputString: string) : void {
+        /** A stack to which we push starting html tags and pop them once we encounter the closing tag */
+        let stack = new Array<{ tag: string, offsetPost: number}>;
+
+        /** The current index we are at within the prosemirror content elem */
+        let offsetProse: number = 0; 
+
+        /** The current index we are at within the raw vscode text document */
+        let offsetText: number = 0;
+
+        /** This represents whether we are currently within a coqdoc block */
+        let inCoqdoc: boolean = false; 
+
+        // Continue until the entire string has been parsed
+        while(inputString.length > 0) { 
+            const next: TagInformation = TextDocMapping.getNextHTMLtag(inputString);
+            let nextCell: StringCell | undefined = undefined;
+            
+            /** The number of characters the tag `next` takes up in the raw vscode doc. */
+            let textCost = 0;
+
+            // Check whether `next` is a closing tag
+            if (stack.length && stack[stack.length - 1].tag === next.content) {
+                let stackTag = stack.pop();
+                if (stackTag === undefined) throw new Error(" Stack returned undefined in initialization of vscode mapping");
+                nextCell = { 
+                    startProse: offsetProse, endProse: offsetProse + next.start, 
+                    startText: offsetText, endText: offsetText + next.start,
+                };
+                textCost += stackTag.offsetPost; // Increment for the post newlines
+                textCost += getEndHtmlTagText(next.content).length;                
+            } else { // Otherwise `next` opens a block
+                stack.push({ tag: next.content, offsetPost: next.postNumber}); // Push new tag to stack
+                // Add text offset based on tag
+                if (next.content == "hint") textCost += inputString.slice(next.start, next.end).length;
+                else textCost += getStartHtmlTagText(next.content).length;
+
+                textCost += next.preNumber;
+
+            }
+            // Update offsets, so we are at the start of this tag
+            offsetText += next.start;
+            offsetProse += next.start;
+
+            // Add start information of this tag to mapping
+            this.startHtmlMap.set(offsetProse,{ offsetText: offsetText, offsetProse: offsetProse, textCost: textCost});
+
+            // Update offsets, so we are at end of tag
+            offsetText += textCost;
+            offsetProse += 1;
+
+            // Add end information of this tag to mapping
+            this.endHtmlMap.set(offsetProse,{ offsetText: offsetText, offsetProse: offsetProse, textCost: textCost});
+
+            // Check if the nextCell should be pushed
+            switch(next.content) {
+                case "coqcode": 
+                case "math-display": case "coqdown":
+                    // If the nextcell is set, push it to mapping
+                    if(!(nextCell === undefined)) this.stringBlocks.set(nextCell.startProse, nextCell);
+                    break;
+            }
+            
+            // Update the input string and cut off the processed text
+            inputString = inputString.slice(next.end);
+            
+        }
+        this.updateInvMapping();
+    }
+
+
+    /** Checks whether the step takes place exclusively within a string cell */
+    private inStringCell(step: ReplaceStep | ReplaceAroundStep) : boolean {
+        let correctCellKey = 0;
+        for (let [key,value] of this.stringBlocks) {
+            if (key > step.from) break;
+            correctCellKey = key;
+        }
+        //@ts-ignore
+        return step.to <= this.stringBlocks.get(correctCellKey)?.endProse;
+    }
+
+    /** Called whenever a step is made in the editor */
+    public stepUpdate(step: Step) : DocChange | WrappingDocChange {
+        if (!(step instanceof ReplaceStep || step instanceof ReplaceAroundStep)) 
+            throw new Error("Step update (in textDocMapping) should not be called with a non document changing step");
+
+        /** Check whether the edit is a text edit and occurs within a stringcell */ 
+        const isText: boolean = (step.slice.content.firstChild === null) ? this.inStringCell(step) : step.slice.content.firstChild.type.name === "text";
+
+        let result : ParsedStep;
+
+        /** Parse the step into a text document change */
+        if (step instanceof ReplaceStep && isText) result = TextUpdate.textUpdate(step, this.stringBlocks, this.endHtmlMap, this.startHtmlMap);
+        else result = NodeUpdate.nodeUpdate(step, this.stringBlocks, this.endHtmlMap, this.startHtmlMap);
+
+        /** Update the mappings */
+        this.startHtmlMap = result.newHtmlMapS;
+        this.endHtmlMap = result.newHtmlMap;
+        this.stringBlocks = result.newMap;
+
+        /** Update the inverse mapping */
+        this.updateInvMapping();
+
+        if ('finalText' in result.result) {
+            if(this.checkDocChange(result.result)) this._version++;
+        } else {
+            if(this.checkDocChange(result.result.firstEdit) || this.checkDocChange(result.result.secondEdit)) this._version++;
+        }      
+
+        return result.result;
+    }
+
+    /** Constructs a map from stringBlocks that is indexed based on the vscode index instead of prose */
+    public updateInvMapping() {
+        this.invStringBlocks = new Map<number, StringCell>();
+        this.stringBlocks.forEach((value, key) => {
+            this.invStringBlocks.set(value.startText, value)
+        });
+    }
+
+    /**
+     * This checks if the doc change actually changed the document, since vscode
+     * does not register empty changes 
+     */
+    private checkDocChange(change: DocChange) : boolean {
+        if (change.endInFile === change.startInFile && change.finalText.length == 0) return false;
+        return true;
+    }
+
+    /**
+     * Function that returns the next valid html tag in a string. 
+     * Throws an error if no valid html tag is found.
+     * @param The string that contains html tags  
+     * @returns The first valid html tag in the string and the position of this tag in the string
+     */
+    public static getNextHTMLtag(input: string): TagInformation { 
+
+        // Find all html tags (this is necessary for the position and for invalid matches)
+        let matches = Array.from(input.matchAll(/<(\/)?([\w-]+)( [^]*?)?>/g));
+
+        // Loop through all matches 
+        for (let match of matches) {
+
+            // Check if there are no weird matches that we should throw an error on
+            if (match !== null) {
+
+                // Receive information about the matches
+                let length = match[0].length;
+                let start = match.index;
+
+                // Ensure that we always have the position of the string
+                if (start === undefined) {
+                    throw new Error("Index cannot be null");
+                }
+
+                // Compute the end position of the tag
+                let end = start + length;
+
+                // Check if the HTML tag is a valid HTML tag in our parser
+                if (TextDocMapping.HTMLtags.has(match[2])) {
+
+                    // For entry coqblocks we must extract more information about the starting and ending newline
+                    if (match[2] === "coqblock" && match[1] == undefined) {
+
+                        // Get the matches regarding whitespace
+                        let whiteSpaceMatch = match[3]
+
+                        // Helper variables
+                        let preNum = 0
+                        let postNum = 0
+
+                        // We check for the pre whiteline in front of the first coqblock tag
+                        let prePreWhiteMatch = Array.from(whiteSpaceMatch.matchAll(/prePreWhite="(\w*?)"/g))[0]
+                        if (prePreWhiteMatch != null) {
+
+                            // If there is a newline tage we include this in preNum
+                            if (prePreWhiteMatch[1] === "newLine") {
+                                preNum++;
+                            }
+                        }
+
+                        // We check for the post whiteline after the first coqblock tag
+                        let postPreWhiteMatch = Array.from(whiteSpaceMatch.matchAll(/prePostWhite="(\w*?)"/g))[0]
+                        if (postPreWhiteMatch != null) {
+
+                            // If there is a newline tage we include this in preNum
+                            if (postPreWhiteMatch[1] === "newLine") {
+                                preNum++;
+                            }
+                        }   
+
+                        // We check for the pre whiteline in front of the closing coqblock tag
+                        let prePostWhiteMatch = Array.from(whiteSpaceMatch.matchAll(/postPreWhite="(\w*?)"/g))[0]
+                        if (prePostWhiteMatch != null) {
+
+                            // If there is a newline tage we include this in postNum
+                            if (prePostWhiteMatch[1] === "newLine") {
+                                postNum++;
+                            }
+                        }
+
+                        // We check for the post whiteline after the closing coqblock tag
+                        let postPostWhiteMatch = Array.from(whiteSpaceMatch.matchAll(/postPostWhite="(\w*?)"/g))[0]
+                        if (postPostWhiteMatch != null) {
+
+                            // If there is a newline tage we include this in postNum
+                            if (postPostWhiteMatch[1] === "newLine") {
+                                postNum++;
+                            }
+                        }
+
+                        //return the resulting object
+                        return {start: start, end: end, content: match[2], preNumber: preNum, postNumber: postNum}   
+                        
+                    // For coqdoc we repeat the same process
+                    } else if ((match[2] === "coqdoc") && match[1] == undefined){
+
+                        // Get the matches regarding whitespace
+                        let whiteSpaceMatch = match[3]
+
+                        // Helper variables
+                        let preNum = 0
+                        let postNum = 0
+
+                        // Pre coqdoc newline
+                        let preWhiteMatch = Array.from(whiteSpaceMatch.matchAll(/preWhite="(\w*?)"/g))[0]
+                        if (preWhiteMatch != null) {
+                            if (preWhiteMatch[1] === "newLine") {
+                                preNum++;
+                            }
+                        }
+
+                        // Post coqdoc newline
+                        let postWhiteMatch = Array.from(whiteSpaceMatch.matchAll(/postWhite="(\w*?)"/g))[0]
+                        if (postWhiteMatch != null) {
+                            if (postWhiteMatch[1] === "newLine") {
+                                postNum++;
+                            }
+                        } 
+
+                        // Return the result
+                        return {start: start, end: end, content: match[2], preNumber: preNum, postNumber: postNum}            
+                    } else  {
+                        
+                        return {start: start, end: end, content: match[2], preNumber: 0, postNumber: 0}
+                    }
+                    
+                } 
+            } else {
+
+                // WE have incountered an invalid match
+                throw new Error("match is null")
+            }
+        }
+
+        // We have found no valid HTML tags which means the string on input was invalid.
+        throw new Error(" No tag found ");
+        
+    }
+
+
+}
+
+
+


### PR DESCRIPTION
Removed entire description of subproofs being displayed. Furthermore, ensure the goal panel is always scrolled to the top.