### PR TITLE
Changed background color for selected text for more visibility

### DIFF
--- a/editor/src/kroqed-editor/styles/style.css
+++ b/editor/src/kroqed-editor/styles/style.css
@@ -21,7 +21,7 @@
 
 .ProseMirror ::selection {
   color: var(--vscode-editor-selectionForeground);
-  background-color: var(--vscode-editor-selectionBackground);
+  background-color: var(--vscode-list-activeSelectionBackground);
 }
 
 .ProseMirror-selectednode {


### PR DESCRIPTION
Some light themes (e.g. solarized light) have a background color for selected text that has very low visibility. This change fixes that and uses a background color that has much better visibility/contrast.