### PR TITLE
Color input areas red by default

### DIFF
--- a/editor/src/kroqed-editor/styles/input-area.css
+++ b/editor/src/kroqed-editor/styles/input-area.css
@@ -8,10 +8,10 @@
   content: "";
   position: absolute;
   top: 0;
-  left: -4px;
+  left: 0px;
   height: 100%;
-  width: 4px; 
-  background-color: var(--vscode-button-background); 
+  width: 8px; 
+  background-color: var(--vscode-terminal-ansiRed); 
   /* we add a border for some high contrast themes */
   outline: 1px solid var(--vscode-button-border); 
 }


### PR DESCRIPTION
Changed the default color of the input area to red (see attached picture).

![afbeelding](https://github.com/user-attachments/assets/b8a71dd9-3d91-43ff-bc7e-c6d4f300c99e)
