### PR TITLE
Make sure messages about different goals are visibly split

### DIFF
--- a/views/styles/goals.css
+++ b/views/styles/goals.css
@@ -52,4 +52,5 @@ p.num-goals + p.aside {
   padding-bottom: 1ex;
   white-space: pre;
   font-size: var(--vscode-editor-font-size);
+  border-style: none none solid none;
 }

--- a/views/styles/goals.css
+++ b/views/styles/goals.css
@@ -52,5 +52,8 @@ p.num-goals + p.aside {
   padding-bottom: 1ex;
   white-space: pre;
   font-size: var(--vscode-editor-font-size);
-  border-style: none none solid none;
+}
+
+.coq-goal-env + .coq-goal-env {
+  border-style: solid none none none;
 }


### PR DESCRIPTION
Works by adding a black border below the messages about each separate goal. (Even in the case there is only one).

Test by:
Inspecting the goal view after a `Choose :=` and observe that the messages are cleanly split.