### PR TITLE
Temporary fix for undo problem.

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,16 +148,16 @@
         "when": "editorTextFocus && editorLangId == coq || editorTextFocus && editorLangId == coqmarkdown"
       },
       {
-        "command": "waterproof.undo", 
+        "command": "waterproof.undo",
         "key": "ctrl+z",
         "mac": "cmd+z",
-        "when": "editorFocus && activeCustomEditorId == coqEditor.coqEditor"
+        "when": "activeCustomEditorId == coqEditor.coqEditor"
       },
       {
-        "command": "waterproof.redo", 
+        "command": "waterproof.redo",
         "key": "ctrl+y",
         "mac": "cmd+y",
-        "when": "editorFocus && activeCustomEditorId == coqEditor.coqEditor"
+        "when": "activeCustomEditorId == coqEditor.coqEditor"
       }
     ],
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -146,6 +146,18 @@
         "key": "alt+enter",
         "mac": "meta+enter",
         "when": "editorTextFocus && editorLangId == coq || editorTextFocus && editorLangId == coqmarkdown"
+      },
+      {
+        "command": "waterproof.undo", 
+        "key": "ctrl+z",
+        "mac": "cmd+z",
+        "when": "editorFocus && activeCustomEditorId == coqEditor.coqEditor"
+      },
+      {
+        "command": "waterproof.redo", 
+        "key": "ctrl+y",
+        "mac": "cmd+y",
+        "when": "editorFocus && activeCustomEditorId == coqEditor.coqEditor"
       }
     ],
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -146,18 +146,6 @@
         "key": "alt+enter",
         "mac": "meta+enter",
         "when": "editorTextFocus && editorLangId == coq || editorTextFocus && editorLangId == coqmarkdown"
-      },
-      {
-        "command": "waterproof.undo",
-        "key": "ctrl+z",
-        "mac": "cmd+z",
-        "when": "activeCustomEditorId == coqEditor.coqEditor"
-      },
-      {
-        "command": "waterproof.redo",
-        "key": "ctrl+y",
-        "mac": "cmd+y",
-        "when": "activeCustomEditorId == coqEditor.coqEditor"
       }
     ],
     "viewsContainers": {

--- a/src/pm-editor/coqEditor.ts
+++ b/src/pm-editor/coqEditor.ts
@@ -14,6 +14,12 @@ export class CoqEditorProvider implements vscode.CustomTextEditorProvider {
     /** The webview manager of the extension */
     private readonly _manager: WebviewManager;
 
+    registeredHistoryCommands: boolean = false;
+    _undoListener: (() => void) | undefined = undefined;
+    _redoListener: (() => void) | undefined = undefined;
+    _undoCommand: vscode.Disposable | undefined = undefined;
+    _redoCommand: vscode.Disposable | undefined = undefined;
+
     public static register(context: vscode.ExtensionContext, manager: WebviewManager): vscode.Disposable {
         const provider = new CoqEditorProvider(context, manager);
         const providerRegistration = vscode.window.registerCustomEditorProvider(CoqEditorProvider.viewType, provider, {
@@ -37,7 +43,7 @@ export class CoqEditorProvider implements vscode.CustomTextEditorProvider {
         webviewPanel: vscode.WebviewPanel,
         _token: vscode.CancellationToken
     ): Promise<void> {
-        return ProseMirrorWebview.createProseMirrorView(webviewPanel, this._context.extensionUri, document).then((pmView) => {
+        return ProseMirrorWebview.createProseMirrorView(webviewPanel, this._context.extensionUri, document, this).then((pmView) => {
             this._manager.addProseMirrorWebview(pmView);
         }).catch((reason) => {
             console.error(`==> Failed to create editor view. \n==> The reason should be printed below.`);
@@ -45,4 +51,36 @@ export class CoqEditorProvider implements vscode.CustomTextEditorProvider {
         });
     }
 
+
+    public registerHistoryCommandListeners(undoListener: () => void, redoListener: () => void) {
+        this._undoListener = undoListener;
+        this._redoListener = redoListener;
+
+        if (!this.registeredHistoryCommands) {
+            this._context.subscriptions.push(
+                this._undoCommand = vscode.commands.registerCommand('undo', () => {
+                    if (this._undoListener) {
+                        this._undoListener();
+                    }
+                }),
+                this._redoCommand = vscode.commands.registerCommand('redo', () => {
+                    if (this._redoListener) {
+                        this._redoListener();
+                    }
+                })
+            );
+            this.registeredHistoryCommands = true;
+        }
+    }
+
+    public disposeHistoryCommandListeners() {
+        // Improvement: We don't need to dispose of the command if we switch from Waterproof editor to 
+        //              Waterproof editor. In that case updating the listeners suffices.
+        this._undoCommand?.dispose();
+        this._redoCommand?.dispose();
+
+        this._undoListener = undefined;
+        this._redoListener = undefined;
+        this.registeredHistoryCommands = false;
+    }
 }


### PR DESCRIPTION
### Description
Designed as a fix for #97: We add a custom `HistoryChange` edit to our edit queue whenever the user triggers either `waterproof.undo` or `waterproof.redo` using the keybindings `ctrl-z` (`cmd-z`) and `ctrl-y` (`cmd-y`) respectively. This `HistoryChange` edit is added to the queue and upon execution, triggers the regular `undo` and `redo` command.

### Changes
- Added keybindings for `waterproof.undo` and `waterproof.redo` that are only active when the waterproof editor is in focus.
- Changed `handleChangeFromEditor(change: DocChange)` to also accept `change: HistoryChange` and added an implementation for these two edits.

### Testing this PR
Use the editor and change library imports. Don't let the editor 'stabilize' and press `ctrl-z`. The editor state should remain synchronized.
