### PR TITLE
new tab keymap

### DIFF
--- a/editor/src/kroqed-editor/embedded-codemirror/embedded-codemirror-keymap.ts
+++ b/editor/src/kroqed-editor/embedded-codemirror/embedded-codemirror-keymap.ts
@@ -1,10 +1,15 @@
-import { cursorGroupLeft, selectGroupLeft, cursorLineBoundaryLeft, selectLineBoundaryLeft, cursorGroupRight, selectGroupRight, cursorLineBoundaryRight, selectLineBoundaryRight, cursorDocStart, selectDocStart, cursorPageUp, selectPageUp, cursorDocEnd, selectDocEnd, cursorPageDown, selectPageDown, cursorLineBoundaryBackward, selectLineBoundaryBackward, cursorLineBoundaryForward, selectLineBoundaryForward, insertNewlineAndIndent, deleteCharBackward, deleteCharForward, deleteGroupBackward, deleteGroupForward, cursorCharLeft, cursorCharRight, cursorLineDown, cursorLineUp, selectCharLeft, selectCharRight, selectLineDown, selectLineUp, selectAll } from "@codemirror/commands";
+import { cursorGroupLeft, selectGroupLeft, cursorLineBoundaryLeft, selectLineBoundaryLeft, cursorGroupRight, selectGroupRight, cursorLineBoundaryRight, selectLineBoundaryRight, cursorDocStart, selectDocStart, cursorPageUp, selectPageUp, cursorDocEnd, selectDocEnd, cursorPageDown, selectPageDown, cursorLineBoundaryBackward, selectLineBoundaryBackward, cursorLineBoundaryForward, selectLineBoundaryForward, insertNewlineAndIndent, deleteCharBackward, deleteCharForward, deleteGroupBackward, deleteGroupForward, cursorCharLeft, cursorCharRight, cursorLineDown, cursorLineUp, selectCharLeft, selectCharRight, selectLineDown, selectLineUp, selectAll,indentWithTab, indentLess, indentMore,  } from "@codemirror/commands";
 import { KeyBinding } from "@codemirror/view";
-
+import { acceptCompletion } from "@codemirror/autocomplete";
+import { indentUnit } from "@codemirror/language";
+import {EditorState, StateCommand, SelectionRange, ChangeSpec, Line, EditorSelection} from "@codemirror/state"
+import { EditorView as CodeMirror } from "@codemirror/view";
+import { EditorView } from "prosemirror-view";
 /**
  * Filtered set of keybindings taken from
  * https://github.com/codemirror/commands/blob/e27916c9b09d2cedd7e0c9770bff04eeb3696e69/src/commands.ts#L878
  */
+
 export const keybindings: KeyBinding[] = [
     { key: "Mod-A", run: selectAll, preventDefault: true },
     { key: "ArrowLeft", run: cursorCharLeft, shift: selectCharLeft, preventDefault: true },
@@ -33,4 +38,41 @@ export const keybindings: KeyBinding[] = [
     { key: "Delete", run: deleteCharForward },
     { key: "Mod-Backspace", mac: "Alt-Backspace", run: deleteGroupBackward },
     { key: "Mod-Delete", mac: "Alt-Delete", run: deleteGroupForward },
+
+    { key: "Mod-Delete", mac: "Alt-Delete", run: deleteGroupForward },
+    {key: "Tab", run: customTab, preventDefault: false},
 ]
+
+
+
+function changeBySelectedLineCustom(state: EditorState, f: (line: Line, changes: ChangeSpec[], range: SelectionRange) => void) {
+	let atLine = 2
+	return state.changeByRange(range => {
+	  let changes: ChangeSpec[] = []
+	  for (let pos = range.from; pos <= range.to;) {
+		let line = state.doc.lineAt(pos)
+		if (line.number < atLine && (range.empty || range.to > line.from)) {
+		  f(line, changes, range)
+		  atLine = line.number
+		}
+		pos = line.to + 1
+	  }
+	  let changeSet = state.changes(changes)
+	  return {changes,
+			  range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))}
+	})
+  }
+export const indentMoreCustom: StateCommand = ({state, dispatch}) => {
+	if (state.readOnly) return false
+	dispatch(state.update(changeBySelectedLineCustom(state, (line, changes) => {
+	  changes.push({from: line.from, insert: state.facet(indentUnit)})
+	}), {userEvent: "input.indent"}))
+	return true
+  }
+function customTab(view: CodeMirror){	
+	if (acceptCompletion(view)) {
+        return true; 
+    }
+	return indentMoreCustom(view)
+
+}


### PR DESCRIPTION
### Description
New keymap that indents with tab (only the first line of the selection) and can accept an autocomplete suggestion with tab.

### Changes
Created a custom tab function that accepts an autocomplete or if there is no autocomplete to accept indents the selected line. The functions indentMoreCustom and changeBySelectedLineCustom are modified codemirror commands. changeBySelectedLineCustom will only apply the changes to the first line, this is done to remove the incorrectly placed tabs when multiple lines are selected. I tried to fix the indent behavior, but was unable to do this so this is a temporary fix that only applies tab to the first line in the selection.



