### PR TITLE
tab functionality added to indent, if multiple lines selected only fi…

### DIFF
--- a/editor/src/kroqed-editor/codeview/nodeview.ts
+++ b/editor/src/kroqed-editor/codeview/nodeview.ts
@@ -1,7 +1,7 @@
-import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion, snippet, completionKeymap, acceptCompletion } from "@codemirror/autocomplete";
+import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion, snippet, completionKeymap } from "@codemirror/autocomplete";
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { coq, coqSyntaxHighlighting } from "./lang-pack"
-import { Compartment, EditorState, Extension, StateCommand, SelectionRange, ChangeSpec, Line, EditorSelection } from "@codemirror/state"
+import { Compartment, EditorState, Extension } from "@codemirror/state"
 import {
 	EditorView as CodeMirror, keymap as cmKeymap,
 	highlightActiveLine,
@@ -14,44 +14,13 @@ import { EmbeddedCodeMirrorEditor } from "../embedded-codemirror";
 import { linter, LintSource, Diagnostic, setDiagnosticsEffect } from "@codemirror/lint";
 import { Debouncer } from "./debouncer";
 import { INPUT_AREA_PLUGIN_KEY } from "../inputArea";
-import { indentUnit } from "@codemirror/language";
 
 /**
  * Export CodeBlockView class that implements the custom codeblock nodeview.
  * Corresponds with the example as can be found here:
  * https://prosemirror.net/examples/codemirror/
  */
-function changeBySelectedLineCustom(state: EditorState, f: (line: Line, changes: ChangeSpec[], range: SelectionRange) => void) {
-	let atLine = 2
-	return state.changeByRange(range => {
-	  let changes: ChangeSpec[] = []
-	  for (let pos = range.from; pos <= range.to;) {
-		let line = state.doc.lineAt(pos)
-		if (line.number < atLine && (range.empty || range.to > line.from)) {
-		  f(line, changes, range)
-		  atLine = line.number
-		}
-		pos = line.to + 1
-	  }
-	  let changeSet = state.changes(changes)
-	  return {changes,
-			  range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))}
-	})
-  }
-export const indentMoreCustom: StateCommand = ({state, dispatch}) => {
-	if (state.readOnly) return false
-	dispatch(state.update(changeBySelectedLineCustom(state, (line, changes) => {
-	  changes.push({from: line.from, insert: state.facet(indentUnit)})
-	}), {userEvent: "input.indent"}))
-	return true
-  }
-function customTab(view: CodeMirror){	
-	if (acceptCompletion(view)) {
-        return true; 
-    }
-	return indentMoreCustom(view)
 
-}
 export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 	dom: HTMLElement;
 

--- a/editor/src/kroqed-editor/codeview/nodeview.ts
+++ b/editor/src/kroqed-editor/codeview/nodeview.ts
@@ -1,8 +1,7 @@
-import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion, snippet } from "@codemirror/autocomplete";
-import { indentWithTab } from "@codemirror/commands";
+import { Completion, CompletionContext, CompletionResult, CompletionSource, autocompletion, snippet, completionKeymap, acceptCompletion } from "@codemirror/autocomplete";
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { coq, coqSyntaxHighlighting } from "./lang-pack"
-import { Compartment, EditorState, Extension } from "@codemirror/state"
+import { Compartment, EditorState, Extension, StateCommand, SelectionRange, ChangeSpec, Line, EditorSelection } from "@codemirror/state"
 import {
 	EditorView as CodeMirror, keymap as cmKeymap,
 	highlightActiveLine,
@@ -15,13 +14,44 @@ import { EmbeddedCodeMirrorEditor } from "../embedded-codemirror";
 import { linter, LintSource, Diagnostic, setDiagnosticsEffect } from "@codemirror/lint";
 import { Debouncer } from "./debouncer";
 import { INPUT_AREA_PLUGIN_KEY } from "../inputArea";
+import { indentUnit } from "@codemirror/language";
 
 /**
  * Export CodeBlockView class that implements the custom codeblock nodeview.
  * Corresponds with the example as can be found here:
  * https://prosemirror.net/examples/codemirror/
  */
+function changeBySelectedLineCustom(state: EditorState, f: (line: Line, changes: ChangeSpec[], range: SelectionRange) => void) {
+	let atLine = 2
+	return state.changeByRange(range => {
+	  let changes: ChangeSpec[] = []
+	  for (let pos = range.from; pos <= range.to;) {
+		let line = state.doc.lineAt(pos)
+		if (line.number < atLine && (range.empty || range.to > line.from)) {
+		  f(line, changes, range)
+		  atLine = line.number
+		}
+		pos = line.to + 1
+	  }
+	  let changeSet = state.changes(changes)
+	  return {changes,
+			  range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))}
+	})
+  }
+export const indentMoreCustom: StateCommand = ({state, dispatch}) => {
+	if (state.readOnly) return false
+	dispatch(state.update(changeBySelectedLineCustom(state, (line, changes) => {
+	  changes.push({from: line.from, insert: state.facet(indentUnit)})
+	}), {userEvent: "input.indent"}))
+	return true
+  }
+function customTab(view: CodeMirror){	
+	if (acceptCompletion(view)) {
+        return true; 
+    }
+	return indentMoreCustom(view)
 
+}
 export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 	dom: HTMLElement;
 
@@ -58,6 +88,7 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 				linter(this.lintingFunction),
 				this._readOnlyCompartment.of(EditorState.readOnly.of(!this._outerView.editable)),
 				this._lineNumberCompartment.of(this._lineNumbersExtension),
+
 				autocompletion({
 					override: [
 						tacticCompletionSource, 
@@ -66,11 +97,16 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 						coqCompletionSource
 					], 
 					icons: false,
-					addToOptions: [renderIcon]
+					addToOptions: [renderIcon],
+					defaultKeymap: false,
+					
+					
+			
 				}),
 				cmKeymap.of([
-					indentWithTab,
-					...this.embeddedCodeMirrorKeymap()
+				...completionKeymap,
+						...this.embeddedCodeMirrorKeymap()
+					
 				]),
 				customTheme,
 				syntaxHighlighting(defaultHighlightStyle),

--- a/editor/src/kroqed-editor/embedded-codemirror/embedded-codemirror-keymap.ts
+++ b/editor/src/kroqed-editor/embedded-codemirror/embedded-codemirror-keymap.ts
@@ -45,26 +45,19 @@ export const keybindings: KeyBinding[] = [
 
 
 
-function changeBySelectedLineCustom(state: EditorState, f: (line: Line, changes: ChangeSpec[], range: SelectionRange) => void) {
-	let atLine = 2
-	return state.changeByRange(range => {
-	  let changes: ChangeSpec[] = []
-	  for (let pos = range.from; pos <= range.to;) {
-		let line = state.doc.lineAt(pos)
-		if (line.number < atLine && (range.empty || range.to > line.from)) {
-		  f(line, changes, range)
-		  atLine = line.number
-		}
-		pos = line.to + 1
-	  }
-	  let changeSet = state.changes(changes)
-	  return {changes,
-			  range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))}
-	})
+  function changeFirstLine(state: EditorState, f: (line: Line, changes: ChangeSpec[], range: SelectionRange) => void) {
+    return state.changeByRange(range => {
+      let changes: ChangeSpec[] = []
+      let line = state.doc.lineAt(range.from)
+      f(line, changes, range)
+      let changeSet = state.changes(changes)
+      return {changes,
+        range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))}
+    })
   }
 export const indentMoreCustom: StateCommand = ({state, dispatch}) => {
 	if (state.readOnly) return false
-	dispatch(state.update(changeBySelectedLineCustom(state, (line, changes) => {
+	dispatch(state.update(changeFirstLine(state, (line, changes) => {
 	  changes.push({from: line.from, insert: state.facet(indentUnit)})
 	}), {userEvent: "input.indent"}))
 	return true

--- a/editor/src/kroqed-editor/embedded-codemirror/embedded-codemirror-keymap.ts
+++ b/editor/src/kroqed-editor/embedded-codemirror/embedded-codemirror-keymap.ts
@@ -1,10 +1,15 @@
-import { cursorGroupLeft, selectGroupLeft, cursorLineBoundaryLeft, selectLineBoundaryLeft, cursorGroupRight, selectGroupRight, cursorLineBoundaryRight, selectLineBoundaryRight, cursorDocStart, selectDocStart, cursorPageUp, selectPageUp, cursorDocEnd, selectDocEnd, cursorPageDown, selectPageDown, cursorLineBoundaryBackward, selectLineBoundaryBackward, cursorLineBoundaryForward, selectLineBoundaryForward, insertNewlineAndIndent, deleteCharBackward, deleteCharForward, deleteGroupBackward, deleteGroupForward, cursorCharLeft, cursorCharRight, cursorLineDown, cursorLineUp, selectCharLeft, selectCharRight, selectLineDown, selectLineUp, selectAll } from "@codemirror/commands";
+import { cursorGroupLeft, selectGroupLeft, cursorLineBoundaryLeft, selectLineBoundaryLeft, cursorGroupRight, selectGroupRight, cursorLineBoundaryRight, selectLineBoundaryRight, cursorDocStart, selectDocStart, cursorPageUp, selectPageUp, cursorDocEnd, selectDocEnd, cursorPageDown, selectPageDown, cursorLineBoundaryBackward, selectLineBoundaryBackward, cursorLineBoundaryForward, selectLineBoundaryForward, insertNewlineAndIndent, deleteCharBackward, deleteCharForward, deleteGroupBackward, deleteGroupForward, cursorCharLeft, cursorCharRight, cursorLineDown, cursorLineUp, selectCharLeft, selectCharRight, selectLineDown, selectLineUp, selectAll,indentWithTab, indentLess, indentMore,  } from "@codemirror/commands";
 import { KeyBinding } from "@codemirror/view";
-
+import { acceptCompletion } from "@codemirror/autocomplete";
+import { indentUnit } from "@codemirror/language";
+import {EditorState, StateCommand, SelectionRange, ChangeSpec, Line, EditorSelection} from "@codemirror/state"
+import { EditorView as CodeMirror } from "@codemirror/view";
+import { EditorView } from "prosemirror-view";
 /**
  * Filtered set of keybindings taken from
  * https://github.com/codemirror/commands/blob/e27916c9b09d2cedd7e0c9770bff04eeb3696e69/src/commands.ts#L878
  */
+
 export const keybindings: KeyBinding[] = [
     { key: "Mod-A", run: selectAll, preventDefault: true },
     { key: "ArrowLeft", run: cursorCharLeft, shift: selectCharLeft, preventDefault: true },
@@ -33,4 +38,41 @@ export const keybindings: KeyBinding[] = [
     { key: "Delete", run: deleteCharForward },
     { key: "Mod-Backspace", mac: "Alt-Backspace", run: deleteGroupBackward },
     { key: "Mod-Delete", mac: "Alt-Delete", run: deleteGroupForward },
+
+    { key: "Mod-Delete", mac: "Alt-Delete", run: deleteGroupForward },
+    {key: "Tab", run: customTab, preventDefault: false},
 ]
+
+
+
+function changeBySelectedLineCustom(state: EditorState, f: (line: Line, changes: ChangeSpec[], range: SelectionRange) => void) {
+	let atLine = 2
+	return state.changeByRange(range => {
+	  let changes: ChangeSpec[] = []
+	  for (let pos = range.from; pos <= range.to;) {
+		let line = state.doc.lineAt(pos)
+		if (line.number < atLine && (range.empty || range.to > line.from)) {
+		  f(line, changes, range)
+		  atLine = line.number
+		}
+		pos = line.to + 1
+	  }
+	  let changeSet = state.changes(changes)
+	  return {changes,
+			  range: EditorSelection.range(changeSet.mapPos(range.anchor, 1), changeSet.mapPos(range.head, 1))}
+	})
+  }
+export const indentMoreCustom: StateCommand = ({state, dispatch}) => {
+	if (state.readOnly) return false
+	dispatch(state.update(changeBySelectedLineCustom(state, (line, changes) => {
+	  changes.push({from: line.from, insert: state.facet(indentUnit)})
+	}), {userEvent: "input.indent"}))
+	return true
+  }
+function customTab(view: CodeMirror){	
+	if (acceptCompletion(view)) {
+        return true; 
+    }
+	return indentMoreCustom(view)
+
+}

--- a/editor/src/kroqed-editor/markup-views/switchable-view/EditableView.ts
+++ b/editor/src/kroqed-editor/markup-views/switchable-view/EditableView.ts
@@ -1,4 +1,4 @@
-import { indentWithTab } from "@codemirror/commands"
+import { indentWithTab, indentMore, indentLess } from "@codemirror/commands"
 import {
 	EditorView as CodeMirror, ViewUpdate, keymap as cmKeymap,
 	placeholder
@@ -10,7 +10,7 @@ import { Decoration, EditorView } from "prosemirror-view"
 import { SwitchableView } from "./SwitchableView"
 import { editorTheme } from "./EditorTheme"
 import { renderIcon, symbolCompletionSource } from "../../autocomplete"
-import { autocompletion } from "@codemirror/autocomplete"
+import { autocompletion, acceptCompletion } from "@codemirror/autocomplete"
 import { EmbeddedCodeMirrorEditor } from "../../embedded-codemirror"
 
 /**
@@ -18,6 +18,14 @@ import { EmbeddedCodeMirrorEditor } from "../../embedded-codemirror"
  * Corresponds with the example as can be found here:
  * https://prosemirror.net/examples/codemirror/
  */
+
+function customTab(view: CodeMirror){
+	if (acceptCompletion(view)) {
+        return true; 
+    }
+	return indentMore(view)
+
+}
 export class EditableView extends EmbeddedCodeMirrorEditor {
     public view: CodeMirror;
 	private _parent: SwitchableView;
@@ -42,8 +50,12 @@ export class EditableView extends EmbeddedCodeMirrorEditor {
 		this.view = new CodeMirror({
 			doc: this._node.textContent,
 			extensions: [
-				cmKeymap.of([
-					indentWithTab,
+				cmKeymap.of([{
+					key: "Tab",
+					run: customTab, 
+					shift: indentLess,
+					preventDefault: false 
+				},
 					...this.embeddedCodeMirrorKeymap(),
 				]),
 				CodeMirror.updateListener.of(update => this.forwardUpdate(update)),

--- a/editor/src/kroqed-editor/markup-views/switchable-view/EditableView.ts
+++ b/editor/src/kroqed-editor/markup-views/switchable-view/EditableView.ts
@@ -1,4 +1,4 @@
-import { indentWithTab, indentMore, indentLess } from "@codemirror/commands"
+import { indentMore, indentLess } from "@codemirror/commands"
 import {
 	EditorView as CodeMirror, ViewUpdate, keymap as cmKeymap,
 	placeholder
@@ -19,13 +19,6 @@ import { EmbeddedCodeMirrorEditor } from "../../embedded-codemirror"
  * https://prosemirror.net/examples/codemirror/
  */
 
-function customTab(view: CodeMirror){
-	if (acceptCompletion(view)) {
-        return true; 
-    }
-	return indentMore(view)
-
-}
 export class EditableView extends EmbeddedCodeMirrorEditor {
     public view: CodeMirror;
 	private _parent: SwitchableView;
@@ -50,12 +43,7 @@ export class EditableView extends EmbeddedCodeMirrorEditor {
 		this.view = new CodeMirror({
 			doc: this._node.textContent,
 			extensions: [
-				cmKeymap.of([{
-					key: "Tab",
-					run: customTab, 
-					shift: indentLess,
-					preventDefault: false 
-				},
+				cmKeymap.of([
 					...this.embeddedCodeMirrorKeymap(),
 				]),
 				CodeMirror.updateListener.of(update => this.forwardUpdate(update)),


### PR DESCRIPTION
…rst line indented and accept autocomplete

### Description
updated tab behavior. Tab can be used to indent, if multiple line selected then only the first line will indent (temporary fix). Tab also can be used to accept an autocomplete suggestion.

### Changes
A custom tab function, customTab was created in embedded-codemirror-keymaps that accepts a completion if there is one to select, otherwise indents the line.  The codemirror commands indentMore and changeBySelectedLine are modified to only indent the first line of the selection. In EditableView and additional customTab function is added that uses the codemirror command indentMore, as the keymap I defined for tab in embedded-codemirror-keymaps did not work in markdown cells.


