### PR TITLE
Update walkthroughs mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,10 +221,7 @@
             "id": "download-installer-mac",
             "when": "isMac && !hasRemoteServer",
             "title": "Downloading the Installer",
-            "description": "Download the installer using the button below\n[Download the installer](https://www.github.com/impermeable/waterproof-dependencies-installer/releases/latest)\nOr, if manual installation is preferred, follow the steps in the README for your platform.\n[README](https://github.com/impermeable/waterproof-vscode)",
-            "completionEvents": [
-              "onLink:https://www.github.com/impermeable/waterproof-dependencies-installer/releases/latest"
-            ],
+            "description": "Currently only a manual installation is available for Mac, please follow the steps in the README for your platform.\n[README](https://github.com/impermeable/waterproof-vscode)",
             "media": {
               "markdown": "walkthrough-data/initial-setup/download-installer-mac.md"
             }

--- a/walkthrough-data/initial-setup/auto-installer.md
+++ b/walkthrough-data/initial-setup/auto-installer.md
@@ -1,6 +1,7 @@
 # Automatic Installer
 
 The Waterproof checker will also restart automatically, this might take a few seconds.
+(NOTE: The automatics installer only works on Windows systems, if you are on a Mac, please refer to the README on https://github.com/impermeable/waterproof-vscode)
 
 **Starting the Installation**
 

--- a/walkthrough-data/initial-setup/download-installer-mac.md
+++ b/walkthrough-data/initial-setup/download-installer-mac.md
@@ -1,7 +1,11 @@
 # Download the Installer for MacOS and allow execution
 
-1. Download and execute the bundled installer `Waterproof_Background.dmg` from the [release page](https://github.com/impermeable/waterproof-dependencies-installer/releases/latest)
+<!-- 1. Download and execute the bundled installer `Waterproof_Background.dmg` from the [release page](https://github.com/impermeable/waterproof-dependencies-installer/releases/latest)
 
 2. Open the `Waterproof_Background.dmg` and drag `Waterproof_Background.app` into the "Applications" folder. You may need to provide administrative access to do this.
 
-3. Initially, MacOS will likely block the execution of the necessary background program. To fix this issue, click 'Show in Finder', look for Waterproof_Background, Control-click on the Waterproof_Background application and press open. Click 'open' again if a pop-up appears. You may close the application once it has opened. This will ensure that the application is now trusted when using the Waterproof extension in the future.
+3. Initially, MacOS will likely block the execution of the necessary background program. To fix this issue, click 'Show in Finder', look for Waterproof_Background, Control-click on the Waterproof_Background application and press open. Click 'open' again if a pop-up appears. You may close the application once it has opened. This will ensure that the application is now trusted when using the Waterproof extension in the future. -->
+
+1. Currently Waterproof must be downloaded manually, no installer is available for Mac.
+
+2. Follow the steps in the README on https://github.com/impermeable/waterproof-vscode to download the required packages.


### PR DESCRIPTION
### Description
Since we currently do not have a Mac installer available, we need to remove the instructions that refer to the installer in the walkthroughs.
