### PR TITLE
Documentation: Add instructions to set coq-lsp path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ opam install coq-lsp.0.2.2+8.17
 opam install coq-waterproof
 ```
 
+If vscode cannot detect the installation, set the coq-lsp path to the output of `which coq-lsp`. This can be done
+using ctrl+shift+p and selecting "Waterproof: Change Waterproof path".
+Alternatively, make sure that the `PATH` available to vscode contains the coq-lsp binary.
+
 ## Manual Installation on Mac
 
 If the above method did not work for Mac, it is possible to instead install the dependencies manually using opam.

--- a/walkthrough-data/initial-setup/installation-without-installer.md
+++ b/walkthrough-data/initial-setup/installation-without-installer.md
@@ -7,3 +7,7 @@ eval $(opam env)
 opam install coq-lsp.0.2.2+8.17
 opam install coq-waterproof.2.2.0+8.17
 ```
+
+If vscode cannot detect the installation, set the coq-lsp path to the output of `which coq-lsp`. This can be done
+using ctrl+shift+p and selecting "Waterproof: Change Waterproof path".
+Alternatively, make sure that the `PATH` available to vscode contains the coq-lsp binary.


### PR DESCRIPTION
### Description
Add instructions to change path for linux users

### Changes
Just documentation

### Testing this PR
Check if the instructions are proper.

I can't really get a proper solution with something like `eval $(opam env)` to work, so I went with the instruction to set the coq-lsp path, which is actually what I've been working with in practice.
