### PR TITLE
Temporary fix for <5 in mapping input content

### DIFF
--- a/__tests__/editor-content-construction.test.ts
+++ b/__tests__/editor-content-construction.test.ts
@@ -110,6 +110,30 @@ test("TEMP: Leave <hr> in markdown untouched #2", () => {
     }]);
 });
 
+test("TEMP: Works with multiple < signs", () => {
+    const pm = new PostManager();
+
+    expect(fixLessThanBug("```coq\n10<z\n```<input-area>\n10<z\n</input-area>", (msg) => pm.post(msg))).toBe("```coq\n10< z\n```<input-area>\n10< z\n</input-area>");
+    expect(pm.storage).toStrictEqual<Array<Message>>([
+        {
+            type: MessageType.docChange,
+            body: {
+                startInFile: 10,
+                endInFile: 10,
+                finalText: " "
+            }
+        },
+        {
+            type: MessageType.docChange,
+            body: {
+                startInFile: 31 + 1,
+                endInFile: 31 + 1,
+                finalText: " "
+            }
+        }
+    ])
+});
+
 test("checkPrePost #1", () => {
     const pm = new PostManager();
     expect(checkPrePost("```coq\nLemma.\n```", (msg) => pm.post(msg))).toBe("\n```coq\nLemma.\n```\n");

--- a/editor/src/kroqed-editor/editor.ts
+++ b/editor/src/kroqed-editor/editor.ts
@@ -32,7 +32,7 @@ import { InsertionPlace, cmdInsertCoq, cmdInsertLatex, cmdInsertMarkdown } from 
 import { DiagnosticMessage, HistoryChangeType } from "../../../shared/Messages";
 import { DiagnosticSeverity, ThemeIcon } from "vscode";
 import { OS } from "./osType";
-import { checkPrePost } from "./file-utils";
+import { checkPrePost, fixLessThanBug } from "./file-utils";
 
 /**
  * Very basic representation of the acquirable VSCodeApi.
@@ -132,7 +132,9 @@ export class Editor {
 		this._filef = fileFormat;
 		this._translator = new FileTranslator(fileFormat);
 
-		let newContent = checkPrePost(content, (msg: Message) => {
+		let newContent = checkPrePost(fixLessThanBug(content, (msg: Message) => {
+			this.post(msg);
+		}), (msg: Message) => {
 			this.post(msg);
 		});
 		if (newContent !== content) version = version + 1;

--- a/editor/src/kroqed-editor/file-utils.ts
+++ b/editor/src/kroqed-editor/file-utils.ts
@@ -25,10 +25,9 @@ export function checkPrePost(content: string, post: (Message) => void): string {
 // TODO: Temporary fix for the bug that "<z" turns into an html tag.
 export function fixLessThanBug(content: string, post: (Message) => void): string {
     const regexp = /<(?!input-area|hint|br|hr)([\w\d]+)/g;
-    const matches = content.matchAll(regexp).toArray().toSorted((a, b) => a.index - b.index);
+    const matches = content.matchAll(regexp);
     let newContent = content;
     let counter = 0;
-    console.log(matches);
     for (const match of matches) {
         if (match.index === undefined) continue;
         newContent = newContent.substring(0, match.index + 1 + counter) + " " + newContent.substring(match.index + 1 + counter);

--- a/editor/src/kroqed-editor/file-utils.ts
+++ b/editor/src/kroqed-editor/file-utils.ts
@@ -25,14 +25,16 @@ export function checkPrePost(content: string, post: (Message) => void): string {
 // TODO: Temporary fix for the bug that "<z" turns into an html tag.
 export function fixLessThanBug(content: string, post: (Message) => void): string {
     const regexp = /<(?!input-area|hint|br|hr)([\w\d]+)/g;
-    const matches = content.matchAll(regexp);
+    const matches = content.matchAll(regexp).toArray().toSorted((a, b) => a.index - b.index);
     let newContent = content;
+    let counter = 0;
+    console.log(matches);
     for (const match of matches) {
         if (match.index === undefined) continue;
-        newContent = newContent.substring(0, match.index + 1) + " " + newContent.substring(match.index + 1);
-
-        let edit: DocChange = { startInFile: match.index+1, endInFile: match.index+1, finalText: " "};
+        newContent = newContent.substring(0, match.index + 1 + counter) + " " + newContent.substring(match.index + 1 + counter);
+        let edit: DocChange = { startInFile: match.index+1+counter, endInFile: match.index+1+counter, finalText: " "};
         post({type: MessageType.docChange, body: edit});
+        counter++;
     }
     return newContent;
 }

--- a/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
+++ b/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
@@ -258,6 +258,7 @@ export class TextDocMappingMV {
     public static getNextHTMLtag(input: string): TagInformation { 
 
         // Find all html tags (this is necessary for the position and for invalid matches)
+        // TODO: This RegEx matches <5 in the editor, which causes the mapping to fail!
         let matches = Array.from(input.matchAll(/<(\/)?([\w-]+)( [^]*?)?>/g));
 
         // Loop through all matches 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "waterproof",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "waterproof",
-      "version": "0.9.17",
+      "version": "0.9.18",
       "license": "LGPL-2.1-only",
       "dependencies": {
         "@benrbray/prosemirror-math": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "waterproof",
   "displayName": "Waterproof",
   "description": "Waterproof for VSC",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "requiredCoqLspVersion": "==0.2.2",
   "requiredCoqWaterproofVersion": "==2.2.0",
   "contributors": [


### PR DESCRIPTION
This temporary fix creates an edit that adds a space between the less than sign and the character following it, except if it is a known tag in our model ('hint', 'input-area', etc).

