### PR TITLE
Fix Mapping RegEx

### DIFF
--- a/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
+++ b/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
@@ -258,7 +258,7 @@ export class TextDocMappingMV {
     public static getNextHTMLtag(input: string): TagInformation {
 
         // Find all html tags (this is necessary for the position and for invalid matches)
-        let matches = Array.from(input.matchAll(/<(\/)?(input-area|coqblock|coqcode|markdown|math-display|hint)( [^>]*)?>/g));
+        let matches = Array.from(input.matchAll(/<(\/)?(input-area|coqblock|coqcode|markdown|math-display|hint|coqdoc|coqdown)( [^>]*)?>/g));
 
         // Loop through all matches 
         for (let match of matches) {

--- a/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
+++ b/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
@@ -258,7 +258,7 @@ export class TextDocMappingMV {
     public static getNextHTMLtag(input: string): TagInformation {
 
         // Find all html tags (this is necessary for the position and for invalid matches)
-        let matches = Array.from(input.matchAll(/<(\/?)(input-area|coqblock|coqcode|markdown|math-display|hint)( [^>]*)?>/g));
+        let matches = Array.from(input.matchAll(/<(\/)?(input-area|coqblock|coqcode|markdown|math-display|hint)( [^>]*)?>/g));
 
         // Loop through all matches 
         for (let match of matches) {

--- a/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
+++ b/editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts
@@ -255,10 +255,10 @@ export class TextDocMappingMV {
      * @param The string that contains html tags  
      * @returns The first valid html tag in the string and the position of this tag in the string
      */
-    public static getNextHTMLtag(input: string): TagInformation { 
+    public static getNextHTMLtag(input: string): TagInformation {
 
         // Find all html tags (this is necessary for the position and for invalid matches)
-        let matches = Array.from(input.matchAll(/<(\/)?([\w-]+)( [^]*?)?>/g));
+        let matches = Array.from(input.matchAll(/<(\/?)(input-area|coqblock|coqcode|markdown|math-display|hint)( [^>]*)?>/g));
 
         // Loop through all matches 
         for (let match of matches) {


### PR DESCRIPTION
### Description
Update mapping to no longer map non-existent html tags like `<z`, `<5`, etc.

### Changes
- Changed regex responsible for extracting the HTML tags from the document [in the mapping](editor/src/kroqed-editor/mappingModel/mvFile/vscodeMapping.ts) to only match HTML tags that we recognise.

*Comment*: We should add more documentation/code somewhere describing all the tags that we support and what they do.

### Testing this PR
@jim-portegies has posted quite a good testing workflow on #118, testing this should be the same.

