### PR TITLE
Fix: Overlapping diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/autocomplete": "6.18.1",
         "@codemirror/commands": "6.6.2",
         "@codemirror/language": "6.10.3",
-        "@codemirror/lint": "6.8.2",
+        "@codemirror/lint": "^6.8.4",
         "@codemirror/view": "6.27.0",
         "@lezer/highlight": "1.2.1",
         "@lezer/lr": "1.4.2",
@@ -871,13 +871,23 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.2.tgz",
-      "integrity": "sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==",
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.4.tgz",
+      "integrity": "sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
         "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/lint/node_modules/@codemirror/view": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.35.0.tgz",
+      "integrity": "sha512-I0tYy63q5XkaWsJ8QRv5h6ves7kvtrBWjBcnf/bzohFJQc5c14a1AQRdE8QpPF9eMp5Mq2FMm59TCj1gDfE7kw==",
+      "dependencies": {
+        "@codemirror/state": "^6.4.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@codemirror/state": {

--- a/package.json
+++ b/package.json
@@ -492,7 +492,7 @@
     "@codemirror/autocomplete": "6.18.1",
     "@codemirror/commands": "6.6.2",
     "@codemirror/language": "6.10.3",
-    "@codemirror/lint": "6.8.2",
+    "@codemirror/lint": "^6.8.4",
     "@codemirror/view": "6.27.0",
     "@lezer/highlight": "1.2.1",
     "@lezer/lr": "1.4.2",
@@ -522,7 +522,7 @@
     "vscode-languageclient": "8.1.0",
     "vscode-languageserver-types": "3.17.5"
   },
-  "dependenciesComments" : {
+  "dependenciesComments": {
     "@codemirror/view": "Version 6.28.0 breaks ctrl+v for us, possibly due to switch to EditContext API"
   },
   "main": "./out/src/mainNode.js",


### PR DESCRIPTION
PR aimed at fixing #114.

NOTE: This depends on @codemirror/view ^6.35.0 which we do not want to update to as it breaks pasting in the editor (versions 6.28.0 and above). Hence, @codemirror/view is still fixed on 6.27.0

### Description
Short description for this Pull Request.

### Changes
Brief summary of relevant changes.

### Testing this PR
Please explain how we can test this Pull Request. 
What should we watch out for and how can we automatically test this, if possible.

