### PR TITLE
Update line number logic.

### DIFF
--- a/cypress/e2e/line-numbers.cy.ts
+++ b/cypress/e2e/line-numbers.cy.ts
@@ -1,0 +1,51 @@
+/// <reference types="cypress" />
+
+import { MessageType } from "../../shared";
+import { setupTest } from "./util";
+
+const edits = [];
+const initialDocument = "# Title\n<input-area>\n```coq\nDefinition foo := 42.\n```\n</input-area>\n";
+
+const callbacks = {
+    [MessageType.lineNumbers]: (data: any) => {
+        // convert the zero based offset in `data.linenumbers` to line numbers.
+        const lineNumbers = data.linenumbers.map((n: number) => 
+            initialDocument.substring(0, n).split("\n").length - 1);
+
+        cy.window().then((win) => {
+            win.postMessage({
+                type: MessageType.lineNumbers,
+                body: {
+                    linenumbers: lineNumbers,
+                    version: 1,
+                }
+            })
+        
+        });
+    }
+}
+
+describe('Line numbers', () => {
+  beforeEach(() => { setupTest(initialDocument, edits, callbacks); });
+
+  it("Toggle display of line numbers", () => {
+    cy.get('.cm-content').should("exist");
+    cy.get('.cm-gutter').should("not.exist");
+    cy.window().then((win) => {
+        win.postMessage({
+            type: MessageType.setShowLineNumbers,
+            body: true
+        });
+    });
+    cy.wait(1);
+    cy.get('.cm-gutter').should("exist");
+    cy.get('.cm-gutter').should("contain", "4");
+    cy.window().then((win) => {
+        win.postMessage({
+            type: MessageType.setShowLineNumbers,
+            body: false
+        });
+    });
+    cy.get('.cm-gutter').should("not.exist");
+  });
+})

--- a/cypress/e2e/util.ts
+++ b/cypress/e2e/util.ts
@@ -1,11 +1,11 @@
-import {Message} from "../../shared/Messages";
+import {Message, MessageType} from "../../shared/Messages";
 /**
  * Sets up the test harness and initializes the editor after receiving the 
  * ready message from the editor.
  * @param initialDocument The initial document to load in the editor.
  * @param edits Array where the `docChange` events will be stored.
  */
-export function setupTest(initialDocument: string, edits: any[]) {
+export function setupTest(initialDocument: string, edits: any[], callbacks?: Partial<Record<MessageType, Function>> ) {
     cy.visit("../../__test_harness/index.html", {
         onBeforeLoad: (window) => {
             // Supply a 'fake' acquireVsCodeApi function
@@ -13,17 +13,23 @@ export function setupTest(initialDocument: string, edits: any[]) {
             window.acquireVsCodeApi = function () {
                 return {
                     postMessage: (msg: Message) => {
-                        if (msg.type === "ready") {
+                        if (msg.type === MessageType.ready) {
                             window.postMessage({
-                                type: "init",
+                                type: MessageType.init,
                                 body: {
                                     value: initialDocument,
                                     format: "MarkdownV",
                                     version: 1,
                                 }
                             });
-                        } else if (msg.type === "docChange") {
+                        } else if (msg.type === MessageType.docChange) {
                             edits.push(msg.body);
+                        } else {
+                            if (callbacks) {
+                                const callback = callbacks[msg.type];
+                                if (callback !== undefined)
+                                    callback(msg.body);
+                            }
                         }
                     }
                 }

--- a/editor/src/kroqed-editor/codeview/coqcodeplugin.ts
+++ b/editor/src/kroqed-editor/codeview/coqcodeplugin.ts
@@ -78,9 +78,13 @@ let CoqCodePluginSpec:PluginSpec<ICoqCodePluginState> = {
 			}
 
 			// Update the state 
-			if (tr.getMeta(COQ_CODE_PLUGIN_KEY)) {
-				if (tr.getMeta(COQ_CODE_PLUGIN_KEY) === "toggleLines") lineState = !lineState;
-				else newlines = tr.getMeta(COQ_CODE_PLUGIN_KEY);
+			const meta = tr.getMeta(COQ_CODE_PLUGIN_KEY);
+			if (meta) {
+				if (meta.setting === "update")
+					lineState = meta.show;
+				else 
+					newlines = meta;
+				
 				if (value.activeNodeViews.size == newlines.linenumbers.length) {
 					let i = 0;
 					for (let view of value.activeNodeViews) {

--- a/editor/src/kroqed-editor/menubar/menubar.ts
+++ b/editor/src/kroqed-editor/menubar/menubar.ts
@@ -149,8 +149,6 @@ function createDefaultMenu(schema: Schema, outerView: EditorView, filef: any, os
         // Insert LaTeX
         createMenuItem(`${LaTeX_SVG} <div>↓</div>`, `Insert new LaTeX block underneath (${keyBinding("l")})`, cmdInsertLatex(schema, filef, InsertionPlace.Underneath), false),
         createMenuItem(`${LaTeX_SVG} <div>↑</div>`, `Insert new LaTeX block above (${keyBinding("L")})`, cmdInsertLatex(schema, filef, InsertionPlace.Above), false),
-        // Toggle the line numbers in coq code cells.
-        createMenuItem("Line nr", "Toggle Line Numbers", toggleLineNumbers(), false),
         // Select the parent node.
         createMenuItem("Parent", `Select the parent node (${keyBinding(".")})`, selectParentNode, false),
         // in teacher mode, display input area, hint and lift buttons.
@@ -232,17 +230,4 @@ export function menuPlugin(schema: Schema, filef: any, os: OS) {
             },
         }
     })
-}
-
-/**
- * Toggles line numbers for all codeblocks.
- */
-function toggleLineNumbers(): Command {
-   return (state: EditorState, dispatch?: (tr: Transaction) => void) => {
-       if (INPUT_AREA_PLUGIN_KEY.getState(state)?.globalLock) return false;
-       if (dispatch) {
-           dispatch(state.tr.setMeta(COQ_CODE_PLUGIN_KEY, "toggleLines"));
-       }
-       return true; 
-   };
 }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
       {
         "command": "waterproof.setDefaultArgsWin",
         "title": "Waterproof: Set default arguments for Windows"
+      },
+      {
+        "command": "waterproof.toggleInEditorLineNumbers",
+        "title": "Toggle line numbers displayed in editor",
+        "category": "Waterproof"
       }
     ],
     "menus": {
@@ -311,6 +316,11 @@
             "type": "boolean",
             "default": false,
             "description": "Enable detailed errors; if true, errors are displayed at the exact position they correspond to instead of the whole line."
+          },
+          "waterproof.showLineNumbersInEditor": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show line numbers in the Waterproof editor"
           }
         }
       },

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -42,7 +42,8 @@ export enum MessageType {
     fatalError = "fatal",
     updateVersion = "updateTextDocVersion",
     syntax= "setSyntaxMode",
-    editorHistoryChange = "editorHistoryChange"
+    editorHistoryChange = "editorHistoryChange",
+    setShowLineNumbers = "setShowLineNumbers",
 }
 
 export const enum HistoryChangeType {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -267,8 +267,7 @@ export class Waterproof implements Disposable {
         this.registerCommand("toggleInEditorLineNumbers", () => {
             const updated = !WaterproofConfigHelper.showLineNumbersInEditor;
             WaterproofConfigHelper.showLineNumbersInEditor = updated;
-            // Optional show a message to the user
-            // window.showInformationMessage(`Waterproof: Line numbers in editor will now be ${updated ? "shown" : "hidden"}.`);
+            window.showInformationMessage(`Waterproof: Line numbers in editor are now ${updated ? "shown" : "hidden"}.`);
         });
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,6 +263,13 @@ export class Waterproof implements Disposable {
                 this.autoInstall(cmnd)
             }
         });
+
+        this.registerCommand("toggleInEditorLineNumbers", () => {
+            const updated = !WaterproofConfigHelper.showLineNumbersInEditor;
+            WaterproofConfigHelper.showLineNumbersInEditor = updated;
+            // Optional show a message to the user
+            // window.showInformationMessage(`Waterproof: Line numbers in editor will now be ${updated ? "shown" : "hidden"}.`);
+        });
     }
 
     /**

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -17,6 +17,19 @@ export class WaterproofConfigHelper {
         return config().get<boolean>("detailedErrorsMode") as boolean;
     }
 
+    /** `waterproof.showLineNumbersInEditor` */
+    static get showLineNumbersInEditor() {
+        return config().get<boolean>("showLineNumbersInEditor") as boolean;
+    }
+
+    /** `waterproof.showLineNumbersInEditor` */
+    static set showLineNumbersInEditor(value: boolean) {
+        // Update the Waterproof showLineNumbersInEditor configuration
+        // entry, true means we set the global configuration value.
+        config().update("showLineNumbersInEditor", value, true);
+    }
+
+
     /** `waterproof.enforceCorrectNonInputArea` */
     static get enforceCorrectNonInputArea() {
         return config().get<boolean>("enforceCorrectNonInputArea") as boolean;


### PR DESCRIPTION

### Description
Showing line numbers in the editor is now controlled by a global setting within vscode (`waterproof.showLineNumbersInEditor`).

The setting can be toggled using the command `Waterproof Toggle Line Numbers`.

When line numbers are **not** shown, the logic for computing the updated line numbers is disabled. This hopefully causes an increase in performance.

As the setting is now globally applied (can be manually changed per workspace) the line numbers show up upon opening the editor (when they are turned on).

### Changes
- Modified `package.json` to include `waterproof.showLineNumbersInEditor` configuration and `waterproof.toggleInEditorLineNumbers`.
- Remove 'Line Nr' button from the menubar and move relevant logic to `editor.ts`.
- Add a message type `setShowLineNumbers`. This message type is used within the message that is sent from the extension to the editor when toggling the line numbers.
- Add logic to listen to configuration changes for the line numbers.
- Update `WaterproofConfigHelper` to reflect added configuration.

### Testing this PR
1. Open the Waterproof editor.
2. **Note:** The menubar should no longer contain the line number button.
3. Turn on line numbers using the command `Waterproof: Toggle Line ...` or by manually switching the configuration `waterproof.showLineNumbersInEditor` to `true`.
4. **Both** should immediately reflect the change within the editor.
5. Close the editor (or extension) and start it back up.
6. The line numbers should still be shown after restart.

