### PR TITLE
Update documentation on Messages

### DIFF
--- a/developer-resources/README.md
+++ b/developer-resources/README.md
@@ -2,7 +2,7 @@
 This README is intented for **Waterproof developers**. If you are not a developer and are searching installation instructions, you are in the wrong place. Please go to the [Instructions](../README.md).
 
 ## Installation for developers
-Please follow the instructions as specified in [developer_instructions.md](./developer_instructions.md). 
+Please follow the instructions as specified in [developer_instructions.md](./developer_instructions.md).
 
 ## Resources
 ### VSCode styling/theming guide:
@@ -10,5 +10,5 @@ Please follow the instructions as specified in [developer_instructions.md](./dev
 - [Theme Guide](https://code.visualstudio.com/api/extension-guides/color-theme)
 - [Theme Reference](https://code.visualstudio.com/api/references/theme-color) (Includes all available colours)
 
-### Messages: 
-Information about the messages between editor <-> extension see [docs.md](./docs.md) (not up to date).
+### Messages:
+Information about the messages between editor <-> extension see [messages.md](./messages.md).

--- a/developer-resources/docs.md
+++ b/developer-resources/docs.md
@@ -1,45 +1,272 @@
 # Documentation
-## Messages
-The general message structure is as [follows](./shared/):
-```js 
+## General
+
+All types of messages that are sent between editor and extension (and sometimes from extension to extension) are defined in [`shared`](./shared/).
+
+We make use of the type former:
+```ts
+type MessageBase<T extends MessageType, B = undefined> =
+    B extends undefined ? { type: T, requestId?: number } : { type: T, body: B, requestId?: number };
+```
+Notes on the type former:
+- `T extends MessageType` makes sure `T` is a member of the `MessageType` enum.
+- `B = undefined`, defaults `B` to `undefined` (so we don't have to provide for messages that don't include a body)
+- `B extends undefined ? A : B`, is the usual ternary operator `if`. When `B extends undefined` (ie. `B = undefined`)
+   then we choose `A`, otherwise (`B` is an object) we choose `B`.
+
+### Examples:
+`MessageBase<MessageType.ready>` does not contain a body and expands to the type `{ type : MessageType.ready }`
+
+`MessageBase<MessageType.update, { value: string, version: number }>` does contain a body and expands to
+```ts
 {
-    type: MessageType, 
-    body?: any, 
-    requestId?: number
+    type: MessageType.update,
+    body: { value: string, version: number }
 }
 ```
-#### `MessageType.init`
-The message sent by VSCode to start initialization of the webview editor, includes the initial document in `body.value`. Structure of the message: 
-```js
-{
-    type: MessageType.init,
-    body: {
-        value: <Uint8Array>,
-    }
-} 
+## Messages
+### `applyStepError`
+#### Description
+
+#### Body
+```ts
+string
 ```
+
+### `command`
+#### Description
+
+
+#### Body
+```ts
+{
+    command: string, // The command to execute (eg. 'Help.')
+    time?: number    // Time that the command was sent
+}
+```
+
+### `cursorChange`
+#### Description
+
+#### Body
+```ts
+number
+```
+
+### `diagnostics`
+#### Description
+
+#### Body
+```ts
+DiagnosticMessage // Type containing the diagnostics as well as the version of the document the diagnostics correspond to
+```
+
+### `docChange`
+#### Description
+
+#### Body
+```ts
+docChange
+```
+
+### `editorHistoryChange`
+#### Description
+Message sent from the editor to the extension to enqueue a history edit (undo or redo operation).
+
+#### Body
+```ts
+HistoryChangeType // Enum type for history changes (Undo / Redo)
+```
+
+### `editorReady`
+#### Description
+Message sent by the editor to inform the Extension Host that it is ready to be used. That is, at this point we can safely query the content using `getFileData` or get the cursor position.
+
+#### Body
+This message does not have a body.
+
+### `errorGoals`
+#### Description
+
+#### Body
+```ts
+errorGoals
+```
+
+### `fatalError`
+#### Description
+
+#### Body
+```ts
+fatalError
+```
+
+### `init`
+
+#### Description
+Message sent by extension to start initialization of the webview editor, includes the initial document in the body.
+
+#### Body
+```ts
+{
+    value: string,        // Contents of the document
+    format: FileFormat,   // File format of the document (see FileFormat)
+    version: number       // Current version of the document
+}
+```
+
+### `insert`
+#### Description
+Message sent by the extension to inform the editor that a symbol should be inserted.
+
+#### Body
+```ts
+{
+    symbolUnicode: string,      // The unicode character that should be inserted
+    symbolLatex: string,        // The LaTeX command responsible for producing this character
+    type: "symbol" | "tactics", // The type of the insertion ("symbol" for symbols (like alpha), "tactics" for tactics)
+    time: number                // Time that the command was executed
+}
+```
+
+### `lineNumbers`
+#### Description
+
+#### Body
+```ts
+lineNumbers
+```
+
+### `progress`
+#### Description
+
+#### Body
+```ts
+progress
+```
+
+### `qedStatus`
+#### Description
+
+#### Body
+```ts
+qedStatus
+```
+
+### `ready`
+#### Description
+
+#### Body
+```ts
+ready
+```
+
+### `renderGoals`
+#### Description
+
+#### Body
+```ts
+renderGoals
+```
+
+### `requestGoals`
+#### Description
+
+#### Body
+```ts
+requestGoals
+```
+
+### `response`
+#### Description
+
+#### Body
+```ts
+response
+```
+
+### `setAutocomplete`
+#### Description
+
+#### Body
+```ts
+setAutocomplete
+```
+
+### `setData`
+#### Description
+
+#### Body
+```ts
+setData
+```
+
+### `setShowLineNumbers`
+#### Description
+Sent from the extension to the editor to enable/disable line numbers from showing in the editor.
+
+#### Body
+```ts
+boolean // Flag indicating whether line numbers should be turned on or off
+```
+
+### `syntax`
+#### Description
+
+#### Body
+```ts
+syntax
+```
+
+### `teacher`
+#### Description
+Sent from the extension to the editor to enable/disable teacher mode in the editor.
+
+#### Body
+```ts
+boolean // Flag indicating whether teacher mode should be turned on or off
+```
+
+### `update`
+#### Description
+
+#### Body
+```ts
+update
+```
+
+### `updateVersion`
+#### Description
+
+#### Body
+```ts
+updateVersion
+```
+
+# Old
+
 #### `MessageType.getFileData`
-The message sent by VSCode to query the current document content. Structure: 
-```js
+The message sent by VSCode to query the current document content. Body:
+```ts
 {
     type: MessageType.getFileData,
     requestId: <number>
-} 
+}
 ```
 
 #### `MessageType.response`
-Response message sent from the editor, will resolve a promise on the Extension side. 
-```js
+Response message sent from the editor, will resolve a promise on the Extension side.
+```ts
 {
-    type: MessageType.response, 
+    type: MessageType.response,
     requestId: <number>,
     body: any
 }
 ```
 
 #### `MessageType.redo`
-Message sent by VSCode when the editor should execute an undo event. 
-```js
+Message sent by VSCode when the editor should execute an undo event.
+```ts
 {
     type: MessageType.redo
 }
@@ -47,52 +274,34 @@ Message sent by VSCode when the editor should execute an undo event.
 
 #### `MessageType.undo`
 Message sent by VSCode when the editor should execute a redo event.
-```js
-{ 
+```ts
+{
     type: MessageType.undo
 }
 ```
 
 #### `MessageType.update`
 Message sent by the Extension Host to inform the internal editor that the content has been updated.
-```js
+```ts
 {
     type: MessageType.update
 }
 ```
 
 #### `MessageType.ready`
-Message sent by the editor to inform the Extension Host that it is ready to recieve messages. 
-```js
+Message sent by the editor to inform the Extension Host that it is ready to recieve messages.
+```ts
 {
     type: MessageType.ready
 }
 ```
 
-#### `MessageType.editorReady`
-Message sent by the editor to inform the Extension Host that it is ready to be used. Ie. at this point we can safely query the content using `getFileData` or get the cursor position.
-```js
-{
-    type: MessageType.editorReady
-}
-```
 
 #### `MessageType.docChange`
 Message sent by the editor to inform the Extension Host that an edit has been made in the prosemirror instance.
-```js
+```ts
 {
     type: MessageType.docChange
 }
 ```
 
-#### `MessageType.insertSymbol`
-Message sent by the Extension Host to inform the editor that a symbol should be inserted. 
-```js
-{
-    type: MessageType.insertSymbol, 
-    body: {
-        symbolUnicode: <unicode character(s) of the symbol>, 
-        symbolLaTeX: <latex command to produce the character(s)>
-    }
-}
-```

--- a/developer-resources/docs.md
+++ b/developer-resources/docs.md
@@ -17,11 +17,11 @@ Notes on the type former:
 ### Examples:
 `MessageBase<MessageType.ready>` does not contain a body and expands to the type `{ type : MessageType.ready }`
 
-`MessageBase<MessageType.update, { value: string, version: number }>` does contain a body and expands to
+`MessageBase<MessageType.command, { command: string, time?: number}>` does contain a body and expands to
 ```ts
 {
-    type: MessageType.update,
-    body: { value: string, version: number }
+    command: string,
+    time?: number
 }
 ```
 ## Messages
@@ -157,11 +157,10 @@ qedStatus
 
 ### `ready`
 #### Description
+The editor sends this message to the extension when it is initialized and ready to react to other messages.
 
 #### Body
-```ts
-ready
-```
+This message does not have a body.
 
 ### `renderGoals`
 #### Description
@@ -181,26 +180,32 @@ requestGoals
 
 ### `response`
 #### Description
+This message is the response of another message and will call the callback associated with this request (passes the body as arguments to the callback function). See [`webviewManager.ts`](../src/webviewManager.ts) for the implementation.
 
 #### Body
 ```ts
-response
+{
+    data: unknown,      // The data belonging to the callback
+    requestId: number   // (Unique) id that this response belongs to
+}
 ```
 
 ### `setAutocomplete`
 #### Description
+Send by the extension to the editor when the set of autocompletions changes, for example when a new definition was added to the document.
 
 #### Body
 ```ts
-setAutocomplete
+Completion[] // The array of completions every CodeMirror cell receives.
 ```
 
 ### `setData`
 #### Description
+Message send by panel controllers to panels to update the data shown within the panel. For example, the goals controller updates the goals shown in the panel.
 
 #### Body
 ```ts
-setData
+string[] | GoalAnswer<PpString> // TODO
 ```
 
 ### `setShowLineNumbers`
@@ -214,10 +219,11 @@ boolean // Flag indicating whether line numbers should be turned on or off
 
 ### `syntax`
 #### Description
+Message send by the extension when the syntax mode should be updated. Currently, the two available modes are Waterproof syntax (`false`) or plain Coq syntax (`true`).
 
 #### Body
 ```ts
-syntax
+boolean // If true, standard Coq syntax completions are given. If false, Waterproof tactic completions are given instead.
 ```
 
 ### `teacher`
@@ -228,82 +234,3 @@ Sent from the extension to the editor to enable/disable teacher mode in the edit
 ```ts
 boolean // Flag indicating whether teacher mode should be turned on or off
 ```
-
-### `update`
-#### Description
-
-#### Body
-```ts
-update
-```
-
-### `updateVersion`
-#### Description
-
-#### Body
-```ts
-updateVersion
-```
-
-# Old
-
-#### `MessageType.getFileData`
-The message sent by VSCode to query the current document content. Body:
-```ts
-{
-    type: MessageType.getFileData,
-    requestId: <number>
-}
-```
-
-#### `MessageType.response`
-Response message sent from the editor, will resolve a promise on the Extension side.
-```ts
-{
-    type: MessageType.response,
-    requestId: <number>,
-    body: any
-}
-```
-
-#### `MessageType.redo`
-Message sent by VSCode when the editor should execute an undo event.
-```ts
-{
-    type: MessageType.redo
-}
-```
-
-#### `MessageType.undo`
-Message sent by VSCode when the editor should execute a redo event.
-```ts
-{
-    type: MessageType.undo
-}
-```
-
-#### `MessageType.update`
-Message sent by the Extension Host to inform the internal editor that the content has been updated.
-```ts
-{
-    type: MessageType.update
-}
-```
-
-#### `MessageType.ready`
-Message sent by the editor to inform the Extension Host that it is ready to recieve messages.
-```ts
-{
-    type: MessageType.ready
-}
-```
-
-
-#### `MessageType.docChange`
-Message sent by the editor to inform the Extension Host that an edit has been made in the prosemirror instance.
-```ts
-{
-    type: MessageType.docChange
-}
-```
-

--- a/developer-resources/docs.md
+++ b/developer-resources/docs.md
@@ -27,34 +27,37 @@ Notes on the type former:
 ## Messages
 ### `applyStepError`
 #### Description
+The editor sends this message when it encounters an error when trying to apply a step from the ProseMirror transaction steps. Used in `dispatchTransaction` in [editor](../editor/src/kroqed-editor/editor.ts).
 
 #### Body
 ```ts
-string
+string // The error message that was reported
 ```
 
 ### `command`
 #### Description
-
+Send by a panel or editor when a 'command' should be executed in the language server. For instance, when the user executes the `Help` command in Waterproof. This message is sent from the panel in charge to the extension with `command: "Help."`.
 
 #### Body
 ```ts
 {
-    command: string, // The command to execute (eg. 'Help.')
+    command: string, // The command to execute (eg. 'Help.' or 'Search "term".')
     time?: number    // Time that the command was sent
 }
 ```
 
 ### `cursorChange`
 #### Description
+The editor sends a `cursorChange` message to the extension when the position of the cursor is updated (The ProseMirror selection is updated).
 
 #### Body
 ```ts
-number
+number // Position of the cursor (offset based) after mapping
 ```
 
 ### `diagnostics`
 #### Description
+Message that contains the diagnostics in the current document which the extension received from the LSP server. Send to the editor upon receiving from the LSP server.
 
 #### Body
 ```ts
@@ -63,15 +66,16 @@ DiagnosticMessage // Type containing the diagnostics as well as the version of t
 
 ### `docChange`
 #### Description
+This message is send by the editor for every change that the extension should apply to the document on disk. The 'steps' are mapped trhough the mapping via the `stepUpdate` member function of the mapping.
 
 #### Body
 ```ts
-docChange
+DocChange | WrappingDocChange // Either the document change that happened (regular insertions or deletions) or a wrapping document change (two insertions that happen *around* some other text, eg when creating an input area)
 ```
 
 ### `editorHistoryChange`
 #### Description
-Message sent from the editor to the extension to enqueue a history edit (undo or redo operation).
+Send from the editor to the extension to enqueue a history edit (undo or redo operation).
 
 #### Body
 ```ts
@@ -93,18 +97,10 @@ This message does not have a body.
 errorGoals
 ```
 
-### `fatalError`
-#### Description
-
-#### Body
-```ts
-fatalError
-```
-
 ### `init`
 
 #### Description
-Message sent by extension to start initialization of the webview editor, includes the initial document in the body.
+Send by the extension to start initialization of the webview editor, includes the initial document in the body. The file format is specified in the shared folder as well, currently `.mv` and `.v` are supported.
 
 #### Body
 ```ts
@@ -117,7 +113,7 @@ Message sent by extension to start initialization of the webview editor, include
 
 ### `insert`
 #### Description
-Message sent by the extension to inform the editor that a symbol should be inserted.
+Send by the extension to inform the editor that a symbol should be inserted.
 
 #### Body
 ```ts
@@ -131,18 +127,24 @@ Message sent by the extension to inform the editor that a symbol should be inser
 
 ### `lineNumbers`
 #### Description
+Send in both directions:
+
+- `editor -> extension` to request updates to the set of line numbers.
+- `extension -> editor` to update the set of line numbers.
+
 
 #### Body
 ```ts
-lineNumbers
+LineNumber // Contains line numbers (as array) and the version of the document they correspond to.
 ```
 
 ### `progress`
 #### Description
 
+
 #### Body
 ```ts
-progress
+SimpleProgressParams // Contains number of lines and a list of program info.
 ```
 
 ### `qedStatus`

--- a/developer-resources/messages.md
+++ b/developer-resources/messages.md
@@ -75,7 +75,7 @@ DocChange | WrappingDocChange // Either the document change that happened (regul
 
 ### `editorHistoryChange`
 #### Description
-Send from the editor to the extension to enqueue a history edit (undo or redo operation).
+Send from the extension to the editor to inform the editor that it should perform either an undo or a redo operation.
 
 #### Body
 ```ts

--- a/developer-resources/messages.md
+++ b/developer-resources/messages.md
@@ -140,7 +140,7 @@ LineNumber // Contains line numbers (as array) and the version of the document t
 
 ### `progress`
 #### Description
-
+Send by the extension and used in the editor to determine up to what point the current file has been verified.
 
 #### Body
 ```ts
@@ -149,10 +149,11 @@ SimpleProgressParams // Contains number of lines and a list of program info.
 
 ### `qedStatus`
 #### Description
+Send by the extension to the editor. This message includes the status for all the input areas. This includes whether they are checked and whether they are correct.
 
 #### Body
 ```ts
-qedStatus
+QedStatus[] // Status per input area, see QedStatus.ts
 ```
 
 ### `ready`
@@ -164,18 +165,11 @@ This message does not have a body.
 
 ### `renderGoals`
 #### Description
+Message send by the extension when the set of goals changes. Panels (goal, logbook, info) listen to this message to update the set of goals that they show.
 
 #### Body
 ```ts
-renderGoals
-```
-
-### `requestGoals`
-#### Description
-
-#### Body
-```ts
-requestGoals
+unknown // TODO: Currently there is no real guarantee on what kind of data is included.
 ```
 
 ### `response`

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -60,9 +60,6 @@ window.onload = () => {
 					?.activeNodeViews
 					?.forEach(codeBlock => codeBlock.handleNewComplete(completions));
 				break; }
-			case MessageType.fatalError:
-				// TODO: show skull
-				break;
 			case MessageType.editorHistoryChange:
 				theEditor.handleHistoryChange(msg.body);
 				break;

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -35,7 +35,7 @@ export type Message =
     | MessageBase<MessageType.errorGoals, unknown>
     | MessageBase<MessageType.fatalError, { error: string }>
     | MessageBase<MessageType.init, { value: string, format: FileFormat, version: number }>
-    | MessageBase<MessageType.insert, { symbolUnicode: string, symbolLatex: string, type: string, time: number }>
+    | MessageBase<MessageType.insert, { symbolUnicode: string, symbolLatex: string, type: "symbol" | "tactics", time: number }>
     | MessageBase<MessageType.lineNumbers, LineNumber>
     | MessageBase<MessageType.progress, SimpleProgressParams>
     | MessageBase<MessageType.qedStatus, QedStatus[]>

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -40,7 +40,6 @@ export type Message =
     | MessageBase<MessageType.qedStatus, QedStatus[]>
     | MessageBase<MessageType.ready>
     | MessageBase<MessageType.renderGoals, unknown>
-    | MessageBase<MessageType.requestGoals, unknown>
     | MessageBase<MessageType.response, { data: unknown, requestId: number }>
     | MessageBase<MessageType.setAutocomplete, Completion[]>
     | MessageBase<MessageType.setData, string[] | GoalAnswer<PpString> >
@@ -68,7 +67,6 @@ export const enum MessageType {
     qedStatus,
     ready,
     renderGoals,
-    requestGoals,
     response,
     setAutocomplete,
     setData,

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -33,7 +33,6 @@ export type Message =
     | MessageBase<MessageType.editorHistoryChange, HistoryChangeType>
     | MessageBase<MessageType.editorReady>
     | MessageBase<MessageType.errorGoals, unknown>
-    | MessageBase<MessageType.fatalError, { error: string }>
     | MessageBase<MessageType.init, { value: string, format: FileFormat, version: number }>
     | MessageBase<MessageType.insert, { symbolUnicode: string, symbolLatex: string, type: "symbol" | "tactics", time: number }>
     | MessageBase<MessageType.lineNumbers, LineNumber>
@@ -56,31 +55,30 @@ export type Message =
  * extension host to the editor (and vice versa) needs to have a type.
  */
 export const enum MessageType {
-    response,
-    update,
-    init,
-    ready,
-    editorReady,
-    docChange,
-    cursorChange,
-    lineNumbers,
-    requestGoals,
-    renderGoals,
-    errorGoals,
-    insert,
-    command,
-    teacher,
-    setAutocomplete,
-    qedStatus,
-    progress,
-    diagnostics,
     applyStepError,
-    fatalError,
-    updateVersion,
-    syntax,
+    command,
+    cursorChange,
+    diagnostics,
+    docChange,
     editorHistoryChange,
-    setShowLineNumbers,
+    editorReady,
+    errorGoals,
+    init,
+    insert,
+    lineNumbers,
+    progress,
+    qedStatus,
+    ready,
+    renderGoals,
+    requestGoals,
+    response,
+    setAutocomplete,
     setData,
+    setShowLineNumbers,
+    syntax,
+    teacher,
+    update,
+    updateVersion,
 }
 
 export const enum HistoryChangeType {

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -15,10 +15,10 @@ import { GoalAnswer, PpString } from "../lib/types";
  *   then we choose A, otherwise (B is an object) we choose B.
  *
  * Ex: MessageBase<MessageType.ready> does not contain a body and expands to { type : MessageType.ready }
- *     MessageBase<MessageType.update, { value: string, version: number }> does contain a body and expands to
+ *     MessageBase<MessageType.command, { command: string, time?: number}> does contain a body and expands to
  *     {
- *          type: MessageType.update,
- *          body: { value: string, version: number }
+ *         command: string,
+ *         time?: number
  *     }
 */
 type MessageBase<T extends MessageType, B = undefined> =
@@ -46,9 +46,7 @@ export type Message =
     | MessageBase<MessageType.setData, string[] | GoalAnswer<PpString> >
     | MessageBase<MessageType.setShowLineNumbers, boolean>
     | MessageBase<MessageType.syntax, boolean>
-    | MessageBase<MessageType.teacher, boolean>
-    | MessageBase<MessageType.update, { value: string, version: number }>
-    | MessageBase<MessageType.updateVersion, { version: number }>;
+    | MessageBase<MessageType.teacher, boolean>;
 
 /**
  * Message type enum. Every message that is send from the
@@ -77,8 +75,6 @@ export const enum MessageType {
     setShowLineNumbers,
     syntax,
     teacher,
-    update,
-    updateVersion,
 }
 
 export const enum HistoryChangeType {

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,5 +1,5 @@
 import { Disposable, Position } from "vscode";
-import { GoalAnswer, GoalRequest, PpString } from "../lib/types";
+import { GoalAnswer, PpString } from "../lib/types";
 import { CoqFileProgressParams } from "./lsp-client/requestTypes";
 
 /**
@@ -48,13 +48,6 @@ export interface IFileProgressComponent extends Disposable {
  * goal and message related information
  */
 export interface IGoalsComponent extends Disposable {
-
-    /**
-     * Update the goals component that a goals request has been sent
-     *
-     * @param cursor the goals request object sent by lsp client
-     */
-    goalRequestSent(cursor: GoalRequest): void;
 
     /**
      * Update the goals component with the latest goals answer

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -484,7 +484,6 @@ export class Waterproof implements Disposable {
     private async updateGoals(document: TextDocument, position: Position): Promise<void> {
         if (!this.client.isRunning()) return;
         const params = this.client.createGoalsRequestParameters(document, position);
-        for (const g of this.goalsComponents) g.goalRequestSent(params)
         this.client.requestGoals(params).then(
             response => {
                 for (const g of this.goalsComponents) g.updateGoals(response)

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -1,5 +1,5 @@
 import { Uri } from "vscode";
-import { GoalAnswer, GoalRequest, PpString } from "../../../lib/types";
+import { GoalAnswer, PpString } from "../../../lib/types";
 import { MessageType } from "../../../shared";
 import { IGoalsComponent } from "../../components";
 import { CoqLspClientConfig } from "../../lsp-client/clientTypes";
@@ -13,11 +13,6 @@ export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
     constructor(extensionUri: Uri, config: CoqLspClientConfig, name: string) {
         super(extensionUri,name);
         this.config = config;
-    }
-
-    //sends message for requestGoals
-    goalRequestSent(cursor: GoalRequest) {
-        this.postMessage({ type: MessageType.requestGoals, body: cursor });
     }
 
     //sends message for renderGoals

--- a/src/webviews/standardviews/execute.ts
+++ b/src/webviews/standardviews/execute.ts
@@ -38,7 +38,7 @@ export class ExecutePanel extends CoqWebview implements IExecutor {
     setResults(results: GoalAnswer<PpString> | string[]): void {
         // Set the data property to the provided results
         this.data = results;
-        // Send a postMessage to the webview with the MessageType.command and the data
+        // Send a postMessage to the webview with the MessageType.setData and the data
         this.postMessage({ type: MessageType.setData, body: this.data });
     }
 }

--- a/src/webviews/standardviews/expandDefinition.ts
+++ b/src/webviews/standardviews/expandDefinition.ts
@@ -37,7 +37,7 @@ export class ExpandDefinition extends CoqWebview implements IExecutor {
     setResults(results: string[]): void {
         // Set the data property to the provided results
         this.data = results;
-        // Send a postMessage to the webview with the MessageType.command and the data
+        // Send a postMessage to the webview with the MessageType.setData and the data
         this.postMessage({ type: MessageType.setData, body: this.data });
     }
 

--- a/src/webviews/standardviews/help.ts
+++ b/src/webviews/standardviews/help.ts
@@ -41,8 +41,8 @@ export class Help extends CoqWebview implements IExecutor {
             this.revealPanel();
         } else {
             // Set the data property to the provided results
-            this.data = results;        
-            // Send a postMessage to the webview with the MessageType.command and the data
+            this.data = results;
+            // Send a postMessage to the webview with the MessageType.setData and the data
             this.postMessage({ type: MessageType.setData, body: this.data })
         }
     }

--- a/src/webviews/standardviews/search.ts
+++ b/src/webviews/standardviews/search.ts
@@ -37,7 +37,7 @@ export class Search extends CoqWebview implements IExecutor {
     setResults(results: string[]): void {
         // Set the data property to the provided results
         this.data = results;
-        // Send a postMessage to the webview with the MessageType.command and the data
+        // Send a postMessage to the webview with the MessageType.setData and the data
         this.postMessage({ type: MessageType.setData, body: this.data })
     }
 


### PR DESCRIPTION
### Description
Update the documentation regarding messages (see developer-resources/docs.md)

### Changes
- Updated the documentation in developer-resources/docs.md
- Removed `fatalError`, `update`, `updateVersion` and `requestGoals` message type (not used for anything)

### Testing this PR
- Proof read documentation in [developer-resources/messages.md](https://github.com/impermeable/waterproof-vscode/blob/documentation/developer-resources/messages.md). 
- Run the extension and test.

Closes #156 
