### PR TITLE
Simple fix for side panel

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,10 +164,10 @@ export class Waterproof implements Disposable {
         this.webviewManager.addToolWebview("tactics", new TacticsPanel(this.context.extensionUri));
         const logbook = new Logbook(this.context.extensionUri, CoqLspClientConfig.create(WaterproofConfigHelper.configuration));
         this.webviewManager.addToolWebview("logbook", logbook);
-        this.goalsComponents.push(logbook);
+        //this.goalsComponents.push(logbook);
         const debug = new DebugPanel(this.context.extensionUri, CoqLspClientConfig.create(WaterproofConfigHelper.configuration));
         this.webviewManager.addToolWebview("debug", debug);
-        this.goalsComponents.push(debug);
+        //this.goalsComponents.push(debug);
 
         this.sidePanelProvider = addSidePanel(context, this.webviewManager);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,10 +164,8 @@ export class Waterproof implements Disposable {
         this.webviewManager.addToolWebview("tactics", new TacticsPanel(this.context.extensionUri));
         const logbook = new Logbook(this.context.extensionUri, CoqLspClientConfig.create(WaterproofConfigHelper.configuration));
         this.webviewManager.addToolWebview("logbook", logbook);
-        //this.goalsComponents.push(logbook);
         const debug = new DebugPanel(this.context.extensionUri, CoqLspClientConfig.create(WaterproofConfigHelper.configuration));
         this.webviewManager.addToolWebview("debug", debug);
-        //this.goalsComponents.push(debug);
 
         this.sidePanelProvider = addSidePanel(context, this.webviewManager);
 


### PR DESCRIPTION
### Description
This has a really simple fix for the behavior of the goals panel on starting the extension. Previously the logbook, and sometimes debug buttons would be greyed out. Now only the goals side panel should be opened and the button greyed out. 

### Changes
I removed two lines that were causing the issue.

### Testing this PR
When I run the extension now, the behavior is as expected (only goals panel opened).

