### PR TITLE
Fixing button transparancy for side panels

### DIFF
--- a/src/webviews/sidePanel.ts
+++ b/src/webviews/sidePanel.ts
@@ -61,7 +61,7 @@ export class SidePanelProvider implements vscode.WebviewViewProvider {
 
     public resolveWebviewView(
         webviewView: vscode.WebviewView,
-        context: vscode.WebviewViewResolveContext,
+        _context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken,
     ) {
         this._view = webviewView;
@@ -101,7 +101,7 @@ export class SidePanelProvider implements vscode.WebviewViewProvider {
     }
 
     // Now we create the actual web page
-    private _getHtmlForWebview(webview: vscode.Webview) {
+    private _getHtmlForWebview(_webview: vscode.Webview) {
         const nonce = getNonce();
 
         // html code for the webview


### PR DESCRIPTION
### Description
This provides a fix for the issue of button transparency in the side panels. Now, when a user reopens the side panel or opens a new document, the opened panels are saved, and the buttons are greyed out. Previously, when a user would reopen the side panel, all the buttons would be reset to their original state, even if panels were opened.

### Changes
I added an event listener for changing the panel visibility (onDidChangeVisibility), as well as a function that keeps track of the buttons that are greyed out (greyedOutButtons). When the side panel is reopened (when onDidChangeVisibility), the side panels that were opened (those in greyedOutButtons) are greyed out.

### Testing this PR
I have tried testing these changes by opening and closing the side panel after clicking open different side panels and by opening new exercise sheets.
