### PR TITLE
Fix bug in handling of help commands

### DIFF
--- a/src/webviewManager.ts
+++ b/src/webviewManager.ts
@@ -271,7 +271,8 @@ export class WebviewManager extends EventEmitter {
                 this.postMessage(id, { type: MessageType.insert, body: msg.body });
                 break; }
             case MessageType.command:
-                this.emit(WebviewManagerEvents.command, this._toolWebviews.get(id), msg.body);
+                // FIXME: The `WebviewManagerEvents` are **not** typed.
+                this.emit(WebviewManagerEvents.command, this._toolWebviews.get(id), msg.body.command);
                 break;
             default:
                 console.error("The message type " + msg.type + " is not currently supported by webview manager");

--- a/views/help/help.tsx
+++ b/views/help/help.tsx
@@ -39,7 +39,8 @@ export function Help() {
     //button press help
     const handleHelp = () => {
         //Send the message indicating the help button was pressed
-        vscode.postMessage({time: date.getTime(), type: MessageType.command, body: "Help."});
+        const msg: Message = { type: MessageType.command, body: {command: "Help.", time: date.getTime()} };
+        vscode.postMessage(msg);
         setIsLoading(true);
     };
     return (


### PR DESCRIPTION
### Description
After refactoring the messages, their was an inconsistency between the messages used for triggering the `Help.` command.

This has now been fixed by fixing the message that is sent to the `WebviewManager`

### Changes
- `src/webviewManager.ts`: The command that we want to execute is stored in the `command` field of the body. The body itself is an object, this has been updated.
- `views/help/help.tsx`: Split `msg: Message` to allow for typechecking of the message. 

### Future Work
We should either remove the `WebviewManager` messages or make sure that they are also properly typed to catch these kinds of bugs.

### Testing this PR
Go through (parts of) the tutorial as usual.
Ask Waterproof for help using the various options available:
- The `help` button in the `Help` panel.
- Clicking the right-mouse-button followed by `? Help.`
- Using the key combination `ctrl-h` (`cmd-h` on Mac) in the editor.
