### PR TITLE
Disable windows and mac unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         node-version: [16.x]
 
     steps:


### PR DESCRIPTION
### Description
Fixes #157 

### Changes
Turns off windows and mac CI for unit tests

### Testing this PR
Check if only Ubuntu runs the unit tests
