### PR TITLE
Add option to disable launch checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,11 @@
             "type": "boolean",
             "default": false,
             "description": "Show line numbers in the Waterproof editor"
+          },
+          "waterproof.skipLaunchChecks": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disables the checks that happen when launching the extension. During those checks Waterproof checks whether Coq, coq-lsp and coq-waterproof are installed. Use at your own risk!"
           }
         }
       },

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -22,6 +22,11 @@ export class WaterproofConfigHelper {
         return config().get<boolean>("showLineNumbersInEditor") as boolean;
     }
 
+    /** `waterproof.skipLaunchChecks` */
+    static get skipLaunchChecks() {
+        return config().get<boolean>("skipLaunchChecks") as boolean;
+    }
+
     /** `waterproof.showLineNumbersInEditor` */
     static set showLineNumbersInEditor(value: boolean) {
         // Update the Waterproof showLineNumbersInEditor configuration


### PR DESCRIPTION
### Description
Adds a setting that disables the launch checks. 

Launch checks normally check for:
- `coq-lsp` installation
- `coq-waterproof` installation and version

Disabling comes at the risk that we try to initialize the client when this is not possible, hence the warning message in the setting.

Closes #180.


### Changes
- Updated `package.json` and `WaterproofConfigHelper` to include new setting. 
- Don't run launch check when the option has been set.

### Testing this PR
1. Run the extension like you normally would. Everything should function as expected.
2. Use `opam switch` to switch to a switch without `coq-waterproof`, without the `skipLaunchChecks` option set this should result in an error message. After turning the option on, the client should start normally. 
