### PR TITLE
Update tactic templates with placeholder at the end

### DIFF
--- a/shared/completions/tactics.json
+++ b/shared/completions/tactics.json
@@ -3,7 +3,7 @@
         "label": "Help.",
         "type": "type",
         "detail": "tactic",
-        "template": "Help.",
+        "template": "Help.${}",
         "description": "Tries to give you a hint on what to do next.",
         "example": "Lemma example_help :\n  0 = 0.\nProof.\nHelp.\nWe conclude that (0 = 0).\nQed.",
         "boost": 2
@@ -12,7 +12,7 @@
         "label": "Take (*name*) : ((*type*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Take ${x} : (${ℝ}).",
+        "template": "Take ${x} : (${ℝ}).${}",
         "description": "Take an arbitrary element from (*type*) and call it (*name*).",
         "example": "Lemma example_take :\n  for all x : ℝ,\n    x = x.\nProof.\nTake x : (ℝ).\nWe conclude that (x = x).\nQed.",
         "boost": 1
@@ -21,7 +21,7 @@
         "label": "Take (*name*) ∈ ((*set*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Take ${x} ∈ (${ℝ}).",
+        "template": "Take ${x} ∈ (${ℝ}).${}",
         "description": "Take an arbitrary element from (*set*) and call it (*name*).",
         "example": "Lemma example_take :\n  ∀ x ∈ ℝ,\n    x = x.\nProof.\nTake x ∈ (ℝ).\nWe conclude that (x = x).\nQed.",
         "boost": 2
@@ -30,7 +30,7 @@
         "label": "Take (*name*) > ((*number*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Take ${0:x} > (${1:0}).",
+        "template": "Take ${0:x} > (${1:0}).${}",
         "description": "Take an arbitrary element larger than (*number*) and call it (*name*).",
         "example": "Lemma example_take :\n  ∀ x > 3,\n    x = x.\nProof.\nTake x > (3).\nWe conclude that (x = x).\nQed.",
         "boost": 2
@@ -39,7 +39,7 @@
         "label": "Take (*name*) ≥ ((*number*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Take ${0:x} ≥ (${1:0}).",
+        "template": "Take ${0:x} ≥ (${1:0}).${}",
         "description": "Take an arbitrary element larger than or equal to (*number*) and call it (*name*).",
         "example": "Lemma example_take :\n  ∀ x ≥ 5,\n    x = x.\nProof.\nTake x ≥ (5).\nWe conclude that (x = x).\nQed.",
         "boost": 2
@@ -48,7 +48,7 @@
         "label": "We need to show that ((*(alternative) formulation of current goal*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "We need to show that (${0 = 0}).",
+        "template": "We need to show that (${0 = 0}).${}",
         "description": "Generally makes a proof more readable. Has the additional functionality that you can write a slightly different but equivalent formulation of the goal: you can for instance change names of certain variables.",
         "example": "Lemma example_we_need_to_show_that :\n  0 = 0.\nProof.\nWe need to show that (0 = 0).\nWe conclude that (0 = 0).\nQed.",
         "boost": 2
@@ -57,7 +57,7 @@
         "label": "We conclude that ((*current goal*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "We conclude that (${0 = 0}).",
+        "template": "We conclude that (${0 = 0}).${}",
         "description": "Tries to automatically prove the current goal.",
         "example": "Lemma example_we_conclude_that :\n  0 = 0.\nProof.\nWe conclude that (0 = 0).\nQed."
     },
@@ -65,7 +65,7 @@
         "label": "We conclude that ((*(alternative) formulation of current goal*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "We conclude that (${0 = 0}).",
+        "template": "We conclude that (${0 = 0}).${}",
         "description": "Tries to automatically prove the current goal.",
         "example": "Lemma example_we_conclude_that :\n  0 = 0.\nProof.\nWe conclude that (0 = 0).\nQed.",
         "boost": 1
@@ -74,7 +74,7 @@
         "label": "Choose (*name_var*) := ((*expression*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Choose ${0:x} := (${1:0}).",
+        "template": "Choose ${0:x} := (${1:0}).${}",
         "description": "You can use this tactic when you need to show that there exists an x such that a certain property holds. You do this by proposing (*expression*) as a choice for x, giving it the name (*name_var*).",
         "boost": 2,
         "example": "Lemma example_choose :\n  ∃ y ∈ ℝ,\n    y < 3.\nProof.\nChoose y := (2).\n* Indeed, (y ∈ ℝ).\n* We conclude that (y < 3).\nQed."
@@ -83,7 +83,7 @@
         "label": "Assume that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Assume that (${0 = 0}).",
+        "template": "Assume that (${0 = 0}).${}",
         "description": "If you need to prove (*statement*) ⇒ B, this allows you to assume that (*statement*) holds.",
         "boost": 2,
         "example": "Lemma example_assume :\n  ∀ a ∈ ℝ, a < 0 ⇒ - a > 0.\nProof.\nTake a ∈ (ℝ).\nAssume that (a < 0).\nWe conclude that (- a > 0).\nQed."
@@ -92,7 +92,7 @@
         "label": "Assume that ((*statement*)) ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Assume that (${0 = 0}) (${i}).",
+        "template": "Assume that (${0 = 0}) (${i}).${}",
         "description": "If you need to prove (*statement*) ⇒ B, this allows you to assume that (*statement*) holds, giving it the label (*label*). You can leave out ((*label*)) if you don't wish to name your assumption.",
         "boost": 1,
         "example": "Lemma example_assume :\n  ∀ a ∈ ℝ, a < 0 ⇒ - a > 0.\nProof.\nTake a ∈ (ℝ).\nAssume that (a < 0) (a_less_than_0).\nWe conclude that (- a > 0).\nQed."
@@ -101,7 +101,7 @@
         "label": "(& 3 < 5 = 2 + 3 ≤ 7) (chain of (in)equalities, with opening parenthesis)",
         "type": "type",
         "detail": "tactic",
-        "template": "(& ${3 < 5 = 2 + 3 ≤ 7}",
+        "template": "(& ${3 < 5 = 2 + 3 ≤ 7}${}",
         "description": "Example of a chain of (in)equalities in which every inequality should.",
         "example": "Lemma example_inequalities :\n  ∀ ε > 0, Rmin(ε,1) < 2.\nProof.\nTake ε > 0.\nWe conclude that (& Rmin(ε,1) ≤ 1 < 2).\nQed."
     },
@@ -109,7 +109,7 @@
         "label": "& 3 < 5 = 2 + 3 ≤ 7 (chain of (in)equalities)",
         "type": "type",
         "detail": "tactic",
-        "template": "& ${3 < 5 = 2 + 3 ≤ 7}",
+        "template": "& ${3 < 5 = 2 + 3 ≤ 7}${}",
         "description": "Example of a chain of (in)equalities in which every inequality should.",
         "example": "Lemma example_inequalities :\n  ∀ ε > 0, Rmin(ε,1) < 2.\nProof.\nTake ε : (ℝ).\nAssume that (ε > 0).\nWe conclude that (& Rmin(ε,1) ≤ 1 < 2).\nQed."
     },
@@ -117,7 +117,7 @@
         "label": "Obtain such a (*name_var*)",
         "type": "type",
         "detail": "tactic",
-        "template": "Obtain such a ${k}.",
+        "template": "Obtain such a ${k}.${}",
         "description": "In case a hypothesis that you just proved starts with 'there exists' s.t. some property holds, then you can use this tactic to select such a variable. The variable will be named (*name_var*).",
         "boost": 2,
         "example": "Lemma example_obtain :\n  ∀ x ∈ ℝ,\n    (∃ y ∈ ℝ, 10 < y ∧ y < x) ⇒\n      10 < x.\nProof.\nTake x ∈ (ℝ).\nAssume that (∃ y ∈ ℝ, 10 < y ∧ y < x) (i).\nObtain such a y.\nQed."
@@ -126,7 +126,7 @@
         "label": "Obtain (*name_var*) according to ((*name_hyp*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Obtain ${k} according to (${i}).",
+        "template": "Obtain ${k} according to (${i}).${}",
         "description": "In case the hypothesis with name (*name_hyp*) starts with 'there exists' s.t. some property holds, then you can use this tactic to select such a variable. The variable will be named (*name_var*).",
         "boost": 2,
         "example": "Lemma example_obtain :\n  ∀ x ∈ ℝ,\n    (∃ y ∈ ℝ, 10 < y ∧ y < x) ⇒\n      10 < x.\nProof.\nTake x ∈ (ℝ).\nAssume that (∃ y ∈ ℝ, 10 < y ∧ y < x) (i).\nObtain y according to (i).\nQed."
@@ -135,7 +135,7 @@
         "label": "It suffices to show that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "It suffices to show that (${0 = 0}).",
+        "template": "It suffices to show that (${0 = 0}).${}",
         "description": "Waterproof tries to verify automatically whether it is indeed enough to show (*statement*) to prove the current goal. If so, (*statement*) becomes the new goal.",
         "boost": 2,
         "example": "Lemma example_it_suffices_to_show_that :\n  ∀ ε > 0,\n      3 + Rmax(ε,2) ≥ 3.\nProof.\nTake ε > 0.\nIt suffices to show that (Rmax(ε,2) ≥ 0).\nWe conclude that (& Rmax(ε,2) ≥ 2 ≥ 0).\nQed.",
@@ -146,7 +146,7 @@
         "type": "type",
         "detail": "tactic",
         "description": "Waterproof tries to verify automatically whether it is indeed enough to show (*statement*) to prove the current goal, using (*lemma or assumption*). If so, (*statement*) becomes the new goal.",
-        "template": "By (${i}) it suffices to show that (${0 = 0}).",
+        "template": "By (${i}) it suffices to show that (${0 = 0}).${}",
         "boost": 2,
         "example": "Lemma example_it_suffices_to_show_that :\n  ∀ ε ∈ ℝ,\n    ε > 0 ⇒\n      3 + Rmax(ε,2) ≥ 3.\nProof.\nTake ε ∈ (ℝ).\nAssume that (ε > 0) (i).\nBy (i) it suffices to show that (Rmax(ε,2) ≥ 0).\nWe conclude that (& Rmax(ε,2) ≥ 2 ≥ 0).\nQed.",
         "advanced": false
@@ -155,7 +155,7 @@
         "label": "It holds that ((*statement*)) ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "It holds that (${0 = 0}) (${i}).",
+        "template": "It holds that (${0 = 0}) (${i}).${}",
         "description": "Tries to automatically prove (*statement*). If that works, (*statement*) is added as a hypothesis with name (*optional_label*).",
         "example": "Lemma example_it_holds_that :\n  ∀ ε > 0,\n    4 - Rmax(ε,1) ≤ 3.\n    \nProof.\nTake ε > 0.\nIt holds that (Rmax(ε,1) ≥ 1) (i).\nWe conclude that (4 - Rmax(ε,1) ≤ 3).\nQed.",
         "boost": 1
@@ -164,7 +164,7 @@
         "label": "It holds that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "It holds that (${0 = 0}).",
+        "template": "It holds that (${0 = 0}).${}",
         "description": "Tries to automatically prove (*statement*). If that works, (*statement*) is added as a hypothesis.",
         "example": "Lemma example_it_holds_that :\n  ∀ ε > 0,\n    4 - Rmax(ε,1) ≤ 3.\n    \nProof.\nTake ε > 0.\nIt holds that (Rmax(ε,1) ≥ 1).\nWe conclude that (4 - Rmax(ε,1) ≤ 3).\nQed.",
         "boost": 2
@@ -173,7 +173,7 @@
         "label": "By ((*lemma or assumption*)) it holds that ((*statement*)) ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "By (${i}) it holds that (${0 = 0}) (${ii}).",
+        "template": "By (${i}) it holds that (${0 = 0}) (${ii}).${}",
         "description": "Tries to prove (*statement*) using (*lemma*) or (*assumption*). If that works, (*statement*) is added as a hypothesis with name (*optional_label*). You can leave out ((*optional_label*)) if you don't wish to name the statement.",
         "example": "Lemma example_forwards :\n  7 < f(-1) ⇒ 2 < f(6).\nProof.\nAssume that (7 < f(-1)).\nBy (f_increasing) it holds that (f(-1) ≤ f(6)) (i).\nWe conclude that (2 < f(6)).\nQed.",
         "boost": 1
@@ -182,7 +182,7 @@
         "label": "By ((*lemma or assumption*)) it holds that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "By (${i}) it holds that (${0 = 0}).",
+        "template": "By (${i}) it holds that (${0 = 0}).${}",
         "description": "Tries to prove (*statement*) using (*lemma*) or (*assumption*). If that works, (*statement*) is added as a hypothesis with name (*optional_label*). You can leave out ((*optional_label*)) if you don't wish to name the statement.",
         "example": "Lemma example_forwards :\n  7 < f(-1) ⇒ 2 < f(6).\nProof.\nAssume that (7 < f(-1)).\nBy (f_increasing) it holds that (f(-1) ≤ f(6)) (i).\nWe conclude that (2 < f(6)).\nQed.",
         "boost": 2
@@ -191,7 +191,7 @@
         "label": "We claim that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "We claim that (${0 = 0}).",
+        "template": "We claim that (${0 = 0}).${}",
         "description": "Lets you first show (*statement*) before continuing with the rest of the proof. After you showed (*statement*), it will be available as a hypothesis with name (*optional_name*).",
         "example": "We claim that (2 = 2) (two_is_two).",
         "boost": 2
@@ -200,7 +200,7 @@
         "label": "We claim that ((*statement*)) ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "We claim that (${0 = 0}) (${i}).",
+        "template": "We claim that (${0 = 0}) (${i}).${}",
         "description": "Lets you first show (*statement*) before continuing with the rest of the proof. After you showed (*statement*), it will be available as a hypothesis with name (*label*).",
         "example": "We claim that (2 = 2) (two_is_two).",
         "boost": 1
@@ -209,7 +209,7 @@
         "label": "We argue by contradiction.",
         "type": "type",
         "detail": "tactic",
-        "template": "We argue by contradiction.",
+        "template": "We argue by contradiction.${}",
         "description": "Assumes the opposite of what you need to show. Afterwards, you need to make substeps that show that both A and ¬ A (i.e. not A) for some statement A. Finally, you can finish your proof with 'Contradiction.'",
         "example": "Lemma example_contradicition :\n  ∀ x ∈ ℝ,\n    (∀ ε > 0, x > 1 - ε) ⇒\n      x ≥ 1.\nProof.\nTake x ∈ (ℝ).\nAssume that (∀ ε > 0, x > 1 - ε) (i).\nWe need to show that (x ≥ 1).\nWe argue by contradiction.\nAssume that (¬ (x ≥ 1)).\nIt holds that ((1 - x) > 0).\nBy (i) it holds that (x > 1 - (1 - x)).\nContradiction.\nQed.",
         "boost": 2
@@ -218,7 +218,7 @@
         "label": "Contradiction",
         "type": "type",
         "detail": "tactic",
-        "template": "Contradiction",
+        "template": "Contradiction.${}",
         "description": "If you have shown both A and not A for some statement A, you can write \"Contradiction\" to finish the proof of the current goal.",
         "example": "Contradiction.",
         "boost": 2
@@ -227,7 +227,7 @@
         "label": "Because ((*name_combined_hyp*)) both ((*statement_1*)) and ((*statement_2*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Because (${i}) both (${0 = 0}) and (${1 = 1}).",
+        "template": "Because (${i}) both (${0 = 0}) and (${1 = 1}).${}",
         "description": "If you currently have a hypothesis with name (*name_combined_hyp*) which is in fact of the form H1 ∧ H2, then this tactic splits it up in two separate hypotheses.",
         "example": "Lemma and_example : for all A B : Prop, A ∧ B ⇒ A.\nTake A : Prop. Take B : Prop.\nAssume that (A ∧ B) (i). Because (i) both (A) (ii) and (B) (iii).",
         "advanced": true,
@@ -237,7 +237,7 @@
         "label": "Because ((*name_combined_hyp*)) both ((*statement_1*)) ((*label_1*)) and ((*statement_2*)) ((*label_2*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Because (${i}) both (${0 = 0}) (${ii}) and (${1 = 1}) (${iii}).",
+        "template": "Because (${i}) both (${0 = 0}) (${ii}) and (${1 = 1}) (${iii}).${}",
         "description": "If you currently have a hypothesis with name (*name_combined_hyp*) which is in fact of the form H1 ∧ H2, then this tactic splits it up in two separate hypotheses.",
         "example": "Lemma and_example : for all A B : Prop, A ∧ B ⇒ A.\nTake A : Prop. Take B : Prop.\nAssume that (A ∧ B) (i). Because (i) both (A) (ii) and (B) (iii).",
         "advanced": true,
@@ -247,7 +247,7 @@
         "label": "Either ((*case_1*)) or ((*case_2*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Either (${0 = 1}) or (${0 ≠ 1}).",
+        "template": "Either (${0 = 1}) or (${0 ≠ 1}).${}",
         "description": "Split in two cases (*case_1*) and (*case_2*).",
         "example": "Lemma example_cases : \n  ∀ x ∈ ℝ, ∀ y ∈ ℝ,\n    Rmax(x,y) = x ∨ Rmax(x,y) = y.\nProof. \nTake x ∈ ℝ. Take y ∈ ℝ.\nEither (x < y) or (x ≥ y).\n- Case (x < y).\n  It suffices to show that (Rmax(x,y) = y).\n  We conclude that (Rmax(x,y) = y).\n- Case (x ≥ y).\n  It suffices to show that (Rmax(x,y) = x).\n  We conclude that (Rmax(x,y) = x).\nQed.",
         "boost": 2
@@ -256,7 +256,7 @@
         "label": "Expand the definition of (*name_kw*).",
         "type": "type",
         "detail": "tactic",
-        "template": "Expand the definition of ${infimum}.",
+        "template": "Expand the definition of ${infimum}.${}",
         "description": "Expands the definition of the keyword (*name_kw*) in relevant statements in the proof, and gives suggestions on how to use them.",
         "example": "Expand the definition of upper bound.",
         "advanced": false,
@@ -266,7 +266,7 @@
         "label": "Expand the definition of (*name_kw*) in ((*expression*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Expand the definition of ${infimum} in (${0 = 0}).",
+        "template": "Expand the definition of ${infimum} in (${0 = 0}).${}",
         "description": "Expands the definition of the keyword (*name_kw*) in the statement (*expression*).",
         "example": "Expand the definition of upper bound in (4 is an upper bound for [0, 3)).",
         "advanced": false,
@@ -276,7 +276,7 @@
         "label": "We show both statements.",
         "type": "type",
         "detail": "tactic",
-        "template": "We show both statements.",
+        "template": "We show both statements.${}",
         "description": "Splits the goal in two separate goals, if it is of the form A ∧ B",
         "example": "Lemma example_both_statements:\n  ∀ x ∈ ℝ, (x^2 ≥ 0) ∧ (| x | ≥ 0).\nProof.\nTake x ∈ (ℝ).\nWe show both statements.\n- We conclude that (x^2 ≥ 0).\n- We conclude that (| x | ≥ 0).\nQed.",
         "boost": 2
@@ -285,7 +285,7 @@
         "label": "We show both directions.",
         "type": "type",
         "detail": "tactic",
-        "template": "We show both directions.",
+        "template": "We show both directions.${}",
         "description": "Splits a goal of the form A ⇔ B, into the goals (A ⇒ B) and (B ⇒ A)",
         "example": "Lemma example_both_directions:\n  ∀ x ∈ ℝ, ∀ y ∈ ℝ,\n    x < y ⇔ y > x.\nProof.\nTake x ∈ (ℝ). Take y ∈ (ℝ).\nWe show both directions.\n- We need to show that (x < y ⇒ y > x).\n  Assume that (x < y).\n  We conclude that (y > x).\n- We need to show that (y > x ⇒ x < y).\n  Assume that (y > x).\n  We conclude that (x < y).\nQed.",
         "boost": 2
@@ -294,7 +294,7 @@
         "label": "We use induction on (*name_var*).",
         "type": "type",
         "detail": "tactic",
-        "template": "We use induction on ${n}.",
+        "template": "We use induction on ${n}.${}",
         "description": "Prove a statement by induction on the variable with (*name_var*).",
         "example": "Lemma example_induction :\n  ∀ n : ℕ → ℕ, (∀ k ∈ ℕ, n(k) < n(k + 1))%nat ⇒\n    ∀ k ∈ ℕ, (k ≤ n(k))%nat.\nProof.\nTake n : (ℕ → ℕ).\nAssume that (∀ k ∈ ℕ, n(k) < n(k + 1))%nat (i).\nWe use induction on k.\n- We first show the base case, namely (0 ≤ n(0))%nat.\n  We conclude that (0 ≤ n(0))%nat.\n- We now show the induction step.\n  Take k ∈ ℕ.\n  Assume that (k ≤ n(k))%nat.\n  By (i) it holds that (n(k) < n(k + 1))%nat.\n  We conclude that (& k + 1 ≤ n(k) + 1 ≤ n(k + 1))%nat.\nQed.",
         "boost": 2
@@ -303,7 +303,7 @@
         "label": "By ((*lemma or assumption*)) we conclude that ((*(alternative) formulation of current goal*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "By (${i}) we conclude that (${0 = 0}).",
+        "template": "By (${i}) we conclude that (${0 = 0}).${}",
         "description": "Tries to directly prove the goal using (*lemma or assumption*) when the goal corresponds to (*statement*).",
         "boost": 2
     },
@@ -311,7 +311,7 @@
         "label": "Define (*name*) := ((*expression*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Define ${0:s} := (${1:0}).",
+        "template": "Define ${0:s} := (${1:0}).${}",
         "description": "Temporarily give the name (*name*) to the expression (*expression*)",
         "boost": 2
     },
@@ -319,7 +319,7 @@
         "label": "Since ((*extra_statement*)) it holds that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Since (${1 = 1}) it holds that (${0 = 0}).",
+        "template": "Since (${1 = 1}) it holds that (${0 = 0}).${}",
         "description": "Tries to first verify (*extra_statement*) after it uses that to verify (*statement*). The statement gets added as a hypothesis.",
         "example": "Since (x = y) it holds that (x = z).",
         "boost": 2
@@ -328,7 +328,7 @@
         "label": "Since ((*extra_statement*)) it holds that ((*statement*)) ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Since (${1 = 1}) it holds that (${0 = 0}) (${i}).",
+        "template": "Since (${1 = 1}) it holds that (${0 = 0}) (${i}).${}",
         "description": "Tries to first verify (*extra_statement*) after it uses that to verify (*statement*). The statement gets added as a hypothesiwe need to show{s, optionally with the name (*optional_label*).",
         "example": "Since (x = y) it holds that (x = z).",
         "boost": 1
@@ -337,7 +337,7 @@
         "label": "Since ((*extra_statement*)) we conclude that ((*(alternative) formulation of current goal*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Since (${1 = 1}) we conclude that (${0 = 0}).",
+        "template": "Since (${1 = 1}) we conclude that (${0 = 0}).${}",
         "description": "Tries to automatically prove the current goal, after first trying to prove (*extra_statement*).",
         "example": "Since (x = y) we conclude that (x = z).",
         "boost": 2
@@ -346,7 +346,7 @@
         "label": "Since ((*extra_statement*)) it suffices to show that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Since (${1 = 1}) it suffices to show that (${0 =  0}).",
+        "template": "Since (${1 = 1}) it suffices to show that (${0 =  0}).${}",
         "description": "Waterproof tries to verify automatically whether it is indeed enough to show (*statement*) to prove the current goal, after first trying to prove (*extra_statement*). If so, (*statement*) becomes the new goal.",
         "example": "Lemma example_backwards :\n  3 < f(0) ⇒ 2 < f(5).\nProof.\nAssume that (3 < f(0)).\nIt suffices to show that (f(0) ≤ f(5)).\nBy (f_increasing) we conclude that (f(0) ≤ f(5)).\nQed.",
         "advanced": false,
@@ -356,7 +356,7 @@
         "label": "Use (*name*) := ((*expression*)) in ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Use ${0:x} := (${1:0}) in (${2:i}).",
+        "template": "Use ${0:x} := (${1:0}) in (${2:i}).${}",
         "description": "Use a forall statement, i.e. apply it to a particular expression.",
         "example": "Lemma example_use_for_all :\n  ∀ x ∈ ℝ,\n    (∀ ε > 0, x < ε) ⇒\n       x + 1/2 < 1.\nProof.\nTake x ∈ ℝ.\nAssume that (∀ ε > 0, x < ε) (i).\nUse ε := (1/2) in (i).\n* Indeed, (1 / 2 > 0).\n* It holds that  (x < 1 / 2).\n  We conclude that (x + 1/2 < 1).\nQed.",
         "advanced": false,
@@ -366,7 +366,7 @@
         "label": "Indeed, ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Indeed, (${0 = 0}).",
+        "template": "Indeed, (${0 = 0}).${}",
         "description": "A synonym for \"We conclude that ((*statement*))\".",
         "example": "Lemma example_choose :\n  ∃ y ∈ ℝ,\n    y < 3.\nProof.\nChoose y := (2).\n* Indeed, (y ∈ ℝ).\n* We conclude that (y < 3).\nQed.",
         "advanced": false,
@@ -376,7 +376,7 @@
         "label": "We need to verify that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "We need to verify that (${0 = 0}).",
+        "template": "We need to verify that (${0 = 0}).${}",
         "description": "Used to indicate what to check after using the \"Choose\" or \"Use\" tactic.",
         "example": "Lemma example_choose :\n  ∃ y ∈ ℝ,\n    y < 3.\nProof.\nChoose y := (2).\n* We need to verify that (y ∈ ℝ).\nWe conclude that (y ∈ ℝ).\n* We conclude that (y < 3).\nQed.",
         "advanced": false,
@@ -386,7 +386,7 @@
         "label": "By magic it holds that ((*statement*)) ((*label*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "By magic it holds that (${0 = 0}) (${i}).",
+        "template": "By magic it holds that (${0 = 0}) (${i}).${}",
         "description": "Postpones the proof of (*statement*), and (*statement*) is added as a hypothesis with name (*optional_label*). You can leave out ((*optional_label*)) if you don't wish to name the statement.",
         "example": "Lemma example_forwards :\n  7 < f(-1) ⇒ 2 < f(6).\nProof.\nAssume that (7 < f(-1)).\nBy magic it holds that (f(-1) ≤ f(6)) (i).\nWe conclude that (2 < f(6)).\nQed.",
         "boost": 1
@@ -395,7 +395,7 @@
         "label": "By magic it holds that ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "By magic it holds that (${0 = 0}).",
+        "template": "By magic it holds that (${0 = 0}).${}",
         "description": "Postpones the proof of (*statement*), and (*statement*) is added as a hypothesis.",
         "example": "Lemma example_forwards :\n  7 < f(-1) ⇒ 2 < f(6).\nProof.\nAssume that (7 < f(-1)).\nBy magic it holds that (f(-1) ≤ f(6)) (i).\nWe conclude that (2 < f(6)).\nQed.",
         "boost": 2
@@ -404,7 +404,7 @@
         "label": "By magic we conclude that ((*(alternative) formulation of current goal*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "By magic we conclude that (${0 = 0}).",
+        "template": "By magic we conclude that (${0 = 0}).${}",
         "description": "Postpones for now the proof of (a possible alternative formulation of) the current goal.",
         "boost": 2
     },
@@ -413,7 +413,7 @@
         "type": "type",
         "detail": "tactic",
         "description": "Postpones for now the proof that (*statement*) is enough to prove the current goal. Now, (*statement*) becomes the new goal.",
-        "template": "By magic it suffices to show that (${0 = 0}).",
+        "template": "By magic it suffices to show that (${0 = 0}).${}",
         "boost": 2,
         "example": "Lemma example_backwards :\n  3 < f(0) ⇒ 2 < f(5).\nProof.\nAssume that (3 < f(0)).\nBy magic it suffices to show that (f(0) ≤ f(5)).\nBy (f_increasing) we conclude that (f(0) ≤ f(5)).\nQed.",
         "advanced": false
@@ -422,7 +422,7 @@
         "label": "Case ((*statement*)).",
         "type": "type",
         "detail": "tactic",
-        "template": "Case (${0 = 0}).",
+        "template": "Case (${0 = 0}).${}",
         "description": "Used to indicate the case after an \"Either\" sentence.",
         "example": "Lemma example_cases : \n  ∀ x ∈ ℝ, ∀ y ∈ ℝ,\n    Rmax(x,y) = x ∨ Rmax(x,y) = y.\nProof. \nTake x ∈ ℝ. Take y ∈ ℝ.\nEither (x < y) or (x ≥ y).\n- Case (x < y).\n  It suffices to show that (Rmax(x,y) = y).\n  We conclude that (Rmax(x,y) = y).\n- Case (x ≥ y).\n  It suffices to show that (Rmax(x,y) = x).\n  We conclude that (Rmax(x,y) = x).\nQed.",
         "boost": 1


### PR DESCRIPTION
### Description
This allows the user to use tab to jump to the end of the line when all the placeholders have been filled in.

I also took the liberty to update the template of the contradiction tactic from `Contradiction` to `Contradiction.`.

Closes #175 

### Changes
Updated the tactic templates in `shared/completions/tactics.json` to include a placeholder at the end of the tactic.


### Testing this PR
Also see #175 

Tabbing after the holes in a tactic have been filled in should no longer indent the line. Instead the cursor should now be placed after the period at the end of the tactic.
