### PR TITLE
Show hypotheses feature toggle

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -143,3 +143,9 @@ export interface DocumentPerfParams {
     summary: string;
     timings: SentencePerfParams[];
 }
+
+export enum HypVisibility {
+  All = "all",
+  Limited = "limited",
+  None = "none"
+}

--- a/package.json
+++ b/package.json
@@ -393,6 +393,16 @@
               "Use jsCoq's Pp rich layout printer",
               "Coq Layout Engine (experimental)"
             ]
+          },
+          "waterproof.hyp_visibilty" : {
+            "type": "string",
+            "default": "none",
+            "enum": [
+              "all",
+              "limited",
+              "none"
+            ],
+            "description": "Visibility of hypotheses in the goals panel.\n- `all`: show all hypotheses\n- `limited`: show only hypotheses not starting with _\n- `none`: do not show any hypotheses\nFor didiactic purposes, we recommend `none` for mathematicians learning proofs and `limited` or `all` for students using the Rocq language."
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -394,7 +394,7 @@
               "Coq Layout Engine (experimental)"
             ]
           },
-          "waterproof.hyp_visibilty" : {
+          "waterproof.hyp_visibility" : {
             "type": "string",
             "default": "none",
             "enum": [

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -39,8 +39,8 @@ export type Message =
     | MessageBase<MessageType.progress, SimpleProgressParams>
     | MessageBase<MessageType.qedStatus, QedStatus[]>
     | MessageBase<MessageType.ready>
-    | MessageBase<MessageType.renderGoals, { goals : GoalAnswer<PpString>[], visibility?: HypVisibility }>
-    | MessageBase<MessageType.renderGoalsLegacy, unknown>
+    | MessageBase<MessageType.renderGoals, { goals : GoalAnswer<PpString>, visibility?: HypVisibility }>
+    | MessageBase<MessageType.renderGoalsList, { goalsList : GoalAnswer<PpString>[]}>
     | MessageBase<MessageType.response, { data: unknown, requestId: number }>
     | MessageBase<MessageType.setAutocomplete, Completion[]>
     | MessageBase<MessageType.setData, string[] | GoalAnswer<PpString> >
@@ -68,7 +68,7 @@ export const enum MessageType {
     qedStatus,
     ready,
     renderGoals,
-    renderGoalsLegacy,
+    renderGoalsList,
     response,
     setAutocomplete,
     setData,

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -4,7 +4,7 @@ import { LineNumber } from "./LineNumber";
 import { DocChange, WrappingDocChange } from "./DocChange";
 import { QedStatus } from "./QedStatus";
 import { Completion } from "@codemirror/autocomplete";
-import { GoalAnswer, PpString } from "../lib/types";
+import { GoalAnswer, HypVisibility, PpString } from "../lib/types";
 
 /** Type former for the `Message` type. A message has an optional body B, but must include a type T (from MessageType)
  *
@@ -39,7 +39,8 @@ export type Message =
     | MessageBase<MessageType.progress, SimpleProgressParams>
     | MessageBase<MessageType.qedStatus, QedStatus[]>
     | MessageBase<MessageType.ready>
-    | MessageBase<MessageType.renderGoals, unknown>
+    | MessageBase<MessageType.renderGoals, { goals : GoalAnswer<PpString>[], visibility?: HypVisibility }>
+    | MessageBase<MessageType.renderGoalsLegacy, unknown>
     | MessageBase<MessageType.response, { data: unknown, requestId: number }>
     | MessageBase<MessageType.setAutocomplete, Completion[]>
     | MessageBase<MessageType.setData, string[] | GoalAnswer<PpString> >
@@ -67,6 +68,7 @@ export const enum MessageType {
     qedStatus,
     ready,
     renderGoals,
+    renderGoalsLegacy,
     response,
     setAutocomplete,
     setData,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,8 +164,10 @@ export class Waterproof implements Disposable {
         this.webviewManager.addToolWebview("tactics", new TacticsPanel(this.context.extensionUri));
         const logbook = new Logbook(this.context.extensionUri, CoqLspClientConfig.create(WaterproofConfigHelper.configuration));
         this.webviewManager.addToolWebview("logbook", logbook);
+        this.goalsComponents.push(logbook);
         const debug = new DebugPanel(this.context.extensionUri, CoqLspClientConfig.create(WaterproofConfigHelper.configuration));
         this.webviewManager.addToolWebview("debug", debug);
+        this.goalsComponents.push(debug);
 
         this.sidePanelProvider = addSidePanel(context, this.webviewManager);
 
@@ -512,7 +514,10 @@ export class Waterproof implements Disposable {
         const params = this.client.createGoalsRequestParameters(document, position);
         this.client.requestGoals(params).then(
             response => {
-                for (const g of this.goalsComponents) g.updateGoals(response)
+                for (const g of this.goalsComponents) {
+                    WaterproofLogger.log(`Updating goals for component: ${g}`);
+                    g.updateGoals(response)
+                }
             },
             reason => {
                 for (const g of this.goalsComponents) g.failedGoals(reason);

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -1,5 +1,6 @@
 import { workspace } from "vscode";
 import { HypVisibility } from "../../lib/types";
+import { WaterproofLogger as wpl } from "./logger";
 
 export class WaterproofConfigHelper {
 
@@ -80,6 +81,7 @@ export class WaterproofConfigHelper {
     /** `waterproof.hyp_visibility` */
     static get hyp_visibility() : HypVisibility {
         const hypVisibility = config().get<string>("hyp_visibility");
+        wpl.log(`Hypothesis visibility set to: ${hypVisibility}`); 
         switch(hypVisibility) {
             case "all":
                 return HypVisibility.All;

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -1,4 +1,5 @@
 import { workspace } from "vscode";
+import { HypVisibility } from "../../lib/types";
 
 export class WaterproofConfigHelper {
 
@@ -77,8 +78,17 @@ export class WaterproofConfigHelper {
 
 
     /** `waterproof.hyp_visibility` */
-    static get hyp_visibility() {
-        return config().get<"all" | "limited" | "none">;
+    static get hyp_visibility() : HypVisibility {
+        const hypVisibility = config().get<string>("hyp_visibility");
+        switch(hypVisibility) {
+            case "all":
+                return HypVisibility.All;
+            case "limited":
+                return HypVisibility.Limited;
+            case "none":
+            default:
+                return HypVisibility.None;
+        }
     }
     /** `waterproof.trace.server` */
     static get trace_server() {

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -75,6 +75,11 @@ export class WaterproofConfigHelper {
         return config().get<number>("pp_type") as number;
     }
 
+
+    /** `waterproof.hyp_visibility` */
+    static get hyp_visibility() {
+        return config().get<"all" | "limited" | "none">;
+    }
     /** `waterproof.trace.server` */
     static get trace_server() {
         return config().get<"off" | "messages" | "verbose">("trace.server") as "off" | "messages" | "verbose";

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -17,7 +17,7 @@ export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
 
     //sends message for renderGoals
     updateGoals(goals: GoalAnswer<PpString> | undefined) {
-        this.postMessage({ type: MessageType.renderGoals, body: goals });
+        this.postMessage({ type: MessageType.renderGoals, body: {goals : goals ? [goals] : []} });
     }
 
     //sends message for errorGoals

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -1,11 +1,10 @@
 import { Uri } from "vscode";
-import { GoalAnswer, HypVisibility, PpString } from "../../../lib/types";
+import { GoalAnswer, PpString } from "../../../lib/types";
 import { MessageType } from "../../../shared";
 import { IGoalsComponent } from "../../components";
 import { CoqLspClientConfig } from "../../lsp-client/clientTypes";
 import { CoqWebview } from "../coqWebview";
 import { WaterproofConfigHelper } from "../../helpers";
-
 //class for panels that need Goals objects from coq-lsp
 export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
 

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -1,9 +1,10 @@
 import { Uri } from "vscode";
-import { GoalAnswer, PpString } from "../../../lib/types";
+import { GoalAnswer, HypVisibility, PpString } from "../../../lib/types";
 import { MessageType } from "../../../shared";
 import { IGoalsComponent } from "../../components";
 import { CoqLspClientConfig } from "../../lsp-client/clientTypes";
 import { CoqWebview } from "../coqWebview";
+import { WaterproofConfigHelper } from "../../helpers";
 
 //class for panels that need Goals objects from coq-lsp
 export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
@@ -17,7 +18,10 @@ export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
 
     //sends message for renderGoals
     updateGoals(goals: GoalAnswer<PpString> | undefined) {
-        this.postMessage({ type: MessageType.renderGoals, body: {goals : goals ? [goals] : []} });
+        if (goals) {
+            const visibility = WaterproofConfigHelper.hyp_visibility;
+            this.postMessage({ type: MessageType.renderGoals, body: {goals, visibility } });
+        }
     }
 
     //sends message for errorGoals

--- a/src/webviews/goalviews/logbook.ts
+++ b/src/webviews/goalviews/logbook.ts
@@ -17,7 +17,7 @@ export class Logbook extends GoalsBase {
         this.on(WebviewEvents.change, () => {
             if (this.state === WebviewState.visible) {
                 // when the panel is visible or focused the messages are sent
-                this.postMessage({ type: MessageType.renderGoalsLegacy, body: this.messages });
+                this.postMessage({ type: MessageType.renderGoalsList, body: {goalsList: this.messages }});
             }
         });
     }
@@ -27,7 +27,7 @@ export class Logbook extends GoalsBase {
         if (!goals) return;
         this.messages.push(goals);
         this.activatePanel();
-        this.postMessage({ type: MessageType.renderGoalsLegacy, body: this.messages });
+        this.postMessage({ type: MessageType.renderGoalsList, body: {goalsList: this.messages }});
     }
 
 }

--- a/src/webviews/goalviews/logbook.ts
+++ b/src/webviews/goalviews/logbook.ts
@@ -4,6 +4,7 @@ import { MessageType } from "../../../shared";
 import { CoqLspClientConfig } from "../../lsp-client/clientTypes";
 import { WebviewEvents, WebviewState } from "../coqWebview";
 import { GoalsBase } from "./goalsBase";
+import { WaterproofLogger } from "../../helpers";
 
 //the logbook panel extends the GoalsBase class
 export class Logbook extends GoalsBase {
@@ -24,6 +25,7 @@ export class Logbook extends GoalsBase {
 
     //override updateGoals to save the previous message and activating the panel before posting the message
     override updateGoals(goals: GoalAnswer<PpString> | undefined) {
+        WaterproofLogger.log(`Logbook: updating goals with ${goals}.`);
         if (!goals) return;
         this.messages.push(goals);
         this.activatePanel();

--- a/src/webviews/goalviews/logbook.ts
+++ b/src/webviews/goalviews/logbook.ts
@@ -17,7 +17,7 @@ export class Logbook extends GoalsBase {
         this.on(WebviewEvents.change, () => {
             if (this.state === WebviewState.visible) {
                 // when the panel is visible or focused the messages are sent
-                this.postMessage({ type: MessageType.renderGoals, body: this.messages });
+                this.postMessage({ type: MessageType.renderGoalsLegacy, body: this.messages });
             }
         });
     }
@@ -27,7 +27,7 @@ export class Logbook extends GoalsBase {
         if (!goals) return;
         this.messages.push(goals);
         this.activatePanel();
-        this.postMessage({ type: MessageType.renderGoals, body: this.messages });
+        this.postMessage({ type: MessageType.renderGoalsLegacy, body: this.messages });
     }
 
 }

--- a/src/webviews/sidePanel.ts
+++ b/src/webviews/sidePanel.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getNonce } from '../util';
 import { WebviewManager, WebviewManagerEvents } from '../webviewManager';
-
+import { WaterproofLogger as wpl} from '../helpers';
 // this function add the side panel to the vs code side panel
 export function addSidePanel(context: vscode.ExtensionContext, manager: WebviewManager) {
     const provider = new SidePanelProvider(context.extensionUri, manager);
@@ -24,6 +24,7 @@ export class SidePanelProvider implements vscode.WebviewViewProvider {
         this._manager.on(WebviewManagerEvents.updateButton, (e) => {
             // Update the transparency of the button based on the event
             // This is done when a panel is open
+            wpl.log(`SidePanelProvider: Updating button transparency for ${e.name} to ${e.open}`); 
             this.updateButtonTransparency(e.name, e.open);
         });
     }

--- a/views/debug/Debug.tsx
+++ b/views/debug/Debug.tsx
@@ -22,9 +22,9 @@ export function Debug() {
   //handles the message
   //event : CoqMessageEvent as defined above
   function infoViewDispatch(msg: Message) {
-    if (msg.type === MessageType.renderGoalsLegacy) {
+    if (msg.type === MessageType.renderGoals) {
       // most important case that actually get the information
-      setGoals(msg.body as GoalAnswer<PpString>);
+      setGoals(msg.body.goals as GoalAnswer<PpString>);
     }
   }
 
@@ -47,7 +47,7 @@ export function Debug() {
       <div className="info-panel">
         
         <Hypothesis  goals={goals.goals} pos={goals.position} textDoc={goals.textDocument}/>
-        <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} visibility={HypVisibility.None}/>
+        <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} visibility={HypVisibility.All}/>
       </div>
 
       {!goals.error ? null : (

--- a/views/debug/Debug.tsx
+++ b/views/debug/Debug.tsx
@@ -1,9 +1,10 @@
-import React, { Suspense, lazy, useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 
 import { GoalAnswer, HypVisibility, PpString } from "../../lib/types";
 import { ErrorBrowser } from "../goals/ErrorBrowser";
 import { Goals } from "../goals/Goals";
-import { Hypothesis } from "./Hypothesis";
+import { Messages } from "../goals/Messages";
+
 
 import "../styles/info.css";
 import { Message, MessageType } from "../../shared";
@@ -17,39 +18,46 @@ const VSCodeDivider = lazy(async () => {
 
 
 export function Debug() {
+  // visibility of the hypotheses in the goals panel
+  
+  //saves the goal
   const [goals, setGoals] = useState<GoalAnswer<PpString>>();
+  //boolean to check if the goals are still loading
+  const [isLoading, setIsLoading] = useState(false);
 
   //handles the message
   //event : CoqMessageEvent as defined above
-  function infoViewDispatch(msg: Message) {
+  function infoViewDispatch(msg: Message) { // TODO: make this change in logbook as well
     if (msg.type === MessageType.renderGoals) {
-      // most important case that actually get the information
-      setGoals(msg.body.goals as GoalAnswer<PpString>);
+      const goals = msg.body.goals;
+
+      setGoals(goals); //setting the information
+      setIsLoading(false);
     }
   }
 
-  // Set the callback, adds and removes the event listener
+  // Set the callback
   useEffect(() => {
     const callback = (ev: MessageEvent<Message>) => {infoViewDispatch(ev.data);};
     window.addEventListener("message", callback);
     return () => window.removeEventListener("message", callback);
   }, []);
 
+  //show that the messages are loading
+  if (isLoading) return <div>Loading...</div>;
+
   if (!goals) {
-    return <div>Place your cursor in the document to show the goals and hypothesis at that position.</div>
+    return <div>Place your cursor in the document to show the goals at that position.</div>
   }
 
-  //the goals and hypothesis are displayed primarily
-  //if an error occurs at the specified line this error will also be displayed
-  //the following components are used: Hypothesis, Goals, ErrorBrowser
+  //The goal and message are displayed along with the error at the position (if it exists)
+  //Components used: Goals, Messages, ErrorBrowser
   return (
     <div className="info-panel-container">
       <div className="info-panel">
-        
-        <Hypothesis  goals={goals.goals} pos={goals.position} textDoc={goals.textDocument}/>
-        <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} visibility={HypVisibility.All}/>
+          <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} visibility={HypVisibility.All}/>
+          <Messages answer={goals} />
       </div>
-
       {!goals.error ? null : (
         <div className="error-browser">
           <Suspense>
@@ -59,7 +67,8 @@ export function Debug() {
         </div>
       )}
     </div>
-  )
+  );
 }
 
 export default Debug;
+

--- a/views/debug/Debug.tsx
+++ b/views/debug/Debug.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy, useEffect, useState } from "react";
 
-import { GoalAnswer, PpString } from "../../lib/types";
+import { GoalAnswer, HypVisibility, PpString } from "../../lib/types";
 import { ErrorBrowser } from "../goals/ErrorBrowser";
 import { Goals } from "../goals/Goals";
 import { Hypothesis } from "./Hypothesis";
@@ -22,9 +22,9 @@ export function Debug() {
   //handles the message
   //event : CoqMessageEvent as defined above
   function infoViewDispatch(msg: Message) {
-    if (msg.type === MessageType.renderGoals) {
+    if (msg.type === MessageType.renderGoalsLegacy) {
       // most important case that actually get the information
-      setGoals(msg.body);
+      setGoals(msg.body as GoalAnswer<PpString>);
     }
   }
 
@@ -45,8 +45,9 @@ export function Debug() {
   return (
     <div className="info-panel-container">
       <div className="info-panel">
+        
         <Hypothesis  goals={goals.goals} pos={goals.position} textDoc={goals.textDocument}/>
-        <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} />
+        <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} visibility={HypVisibility.None}/>
       </div>
 
       {!goals.error ? null : (

--- a/views/debug/Hypothesis.tsx
+++ b/views/debug/Hypothesis.tsx
@@ -16,7 +16,7 @@ import "../styles/goals.css";
 type CoqId = PpString;
 
 //displays the hypothesis as a pp string
-function Hyp({ hyp: { names, def, ty } }: { hyp: Hyp<PpString> }) {
+export function HypEl({ hyp: { names, def, ty } }: { hyp: Hyp<PpString> }) {
   //className to give the right css to the hypothesis, definition or not
   const className = "coq-hypothesis" + (def ? " coq-has-def" : "");
   //a label for the hypothesis
@@ -51,7 +51,7 @@ function Hyps({ hyps }: HypsP) {
     <>
       {hyps.map((v) => {
         const key = objectHash(v);
-        return <Hyp key={key} hyp={v} />;
+        return <HypEl key={key} hyp={v} />;
       })}
     </>
   );

--- a/views/debug/tsconfig.json
+++ b/views/debug/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["**/*.ts", "**/*.tsx", "../../lib/**/*", "../goals/*.tsx", "../../shared/**/*", "../lib/CoqMessage.ts"]
+}

--- a/views/goals/Goals.tsx
+++ b/views/goals/Goals.tsx
@@ -29,6 +29,9 @@ function Goal({ goal }: GoalP) {
   return (
     <div className="coq-goal-env" ref={ref}>
       <div style={{ marginLeft: "1ex" }} ref={tyRef}>
+        {goal.hyps.map((hyp, _) => 
+          <div><CoqPp content={hyp.names[0]} inline={true}/> : <CoqPp content={hyp.ty} inline={true} /></div>
+        )}
         <CoqPp content={goal.ty} inline={false} />
       </div>
     </div>

--- a/views/goals/Goals.tsx
+++ b/views/goals/Goals.tsx
@@ -4,6 +4,7 @@ import { FormatPrettyPrint } from "../../lib/format-pprint/js/main";
 import { convertToString, Goal, GoalConfig, Hyp, HypVisibility, PpString } from "../../lib/types";
 import { Box } from "./Box";
 import { CoqPp } from "./CoqPp";
+import { HypEl } from "../debug/Hypothesis"
 
 import {
   Position,
@@ -48,7 +49,8 @@ function Goal({ goal, visibility }: GoalP) {
     <div className="coq-goal-env" ref={ref}>
       <div style={{ marginLeft: "1ex" }} ref={tyRef}>
         {hyps().map((hyp, _) => 
-          <div><CoqPp content={hyp.names[0]} inline={true}/> : <CoqPp content={hyp.ty} inline={true} /></div>
+          <HypEl hyp={hyp} key={hyp.names[0].toString()} />
+          // <div><CoqPp content={hyp.names[0]} inline={true}/> : <CoqPp content={hyp.ty} inline={true} /></div>
         )}
         <CoqPp content={goal.ty} inline={false} />
       </div>

--- a/views/goals/Info.tsx
+++ b/views/goals/Info.tsx
@@ -1,9 +1,10 @@
 import { Suspense, lazy, useEffect, useState } from "react";
 
-import { GoalAnswer, PpString } from "../../lib/types";
+import { GoalAnswer, HypVisibility, PpString } from "../../lib/types";
 import { ErrorBrowser } from "./ErrorBrowser";
 import { Goals } from "./Goals";
 import { Messages } from "./Messages";
+
 
 import "../styles/info.css";
 import { Message, MessageType } from "../../shared";
@@ -17,16 +18,20 @@ const VSCodeDivider = lazy(async () => {
 
 
 export function InfoPanel() {
+  // visibility of the hypotheses in the goals panel
+  
   //saves the goal
   const [goals, setGoals] = useState<GoalAnswer<PpString>>();
   //boolean to check if the goals are still loading
   const [isLoading, setIsLoading] = useState(false);
+  //visibility of the hypotheses in the goals panel as State
+  const [visibility, setVisibility] = useState<HypVisibility>(HypVisibility.None);
 
   //handles the message
   //event : CoqMessageEvent as defined above
   function infoViewDispatch(msg: Message) { // TODO: make this change in logbook as well
     if (msg.type === MessageType.renderGoals) {
-      const goals = msg.body;
+      const goals = msg.body.goals;
 
       // FIXME: The `renderGoals` message type is currently overloaded and used for very different
       // functions. This can easily be seen when using global search on `MessageType.renderGoals`.
@@ -34,6 +39,7 @@ export function InfoPanel() {
       //@ts-expect-error FIXME: `goals` should be properly typed instead of relying on `unknown`.
       setGoals(goals); //setting the information
       setIsLoading(false);
+      setVisibility(msg.body.visibility ?? HypVisibility.None); //set visibility if it exists, otherwise set to None
     }
   }
 
@@ -56,7 +62,7 @@ export function InfoPanel() {
   return (
     <div className="info-panel-container">
       <div className="info-panel">
-          <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} />
+          <Goals goals={goals.goals} pos={goals.position} textDoc={goals.textDocument} visibility={visibility}/>
           <Messages answer={goals} />
       </div>
       {!goals.error ? null : (

--- a/views/goals/Info.tsx
+++ b/views/goals/Info.tsx
@@ -33,10 +33,6 @@ export function InfoPanel() {
     if (msg.type === MessageType.renderGoals) {
       const goals = msg.body.goals;
 
-      // FIXME: The `renderGoals` message type is currently overloaded and used for very different
-      // functions. This can easily be seen when using global search on `MessageType.renderGoals`.
-      // This should be changed.
-      //@ts-expect-error FIXME: `goals` should be properly typed instead of relying on `unknown`.
       setGoals(goals); //setting the information
       setIsLoading(false);
       setVisibility(msg.body.visibility ?? HypVisibility.None); //set visibility if it exists, otherwise set to None

--- a/views/goals/Messages.tsx
+++ b/views/goals/Messages.tsx
@@ -6,6 +6,7 @@ import {Box} from "./Box";
 import "../styles/messages.css";
 import { PropsWithChildren } from "react";
 
+
 //type that makes a GoalAnswer<PpString> also takes its childrens components with
 export type MessagesInfo = PropsWithChildren<
   {
@@ -16,6 +17,7 @@ export type MessagesInfo = PropsWithChildren<
 //component that takes in the MessagesInfo and displays the list of messages
 export function Messages({answer} : MessagesInfo) {
   const count = answer.messages.length;
+  console.log("Messages: count is ", count);
   //check if there are any messages that need to be shown
   if (count != 0) {
   //the Box component is used to display the messages along with the location

--- a/views/goals/tsconfig.json
+++ b/views/goals/tsconfig.json
@@ -7,5 +7,5 @@
     "esModuleInterop": true,
     "jsx": "react-jsx"
   },
-  "include": ["**/*.ts", "**/*.tsx", "../../lib/**/*", "../logbook/Logbook.tsx", "../debug/ErrorBrowser.tsx", "../../shared/**/*", "../lib/CoqMessage.ts"]
+  "include": ["**/*.ts", "**/*.tsx", "../../lib/**/*", "../logbook/Logbook.tsx", "../debug/ErrorBrowser.tsx", "../debug/Hypothesis.tsx", "../../shared/**/*", "../lib/CoqMessage.ts"]
 }

--- a/views/logbook/Logbook.tsx
+++ b/views/logbook/Logbook.tsx
@@ -16,7 +16,7 @@ export function Logbook() {
 
   //message handler
   function infoViewDispatch(msg: Message) {
-    if (msg.type === MessageType.renderGoals) {
+    if (msg.type === MessageType.renderGoalsLegacy) {
       //@ts-expect-error FIXME: renderGoals body is currently unknown.
       setGoalsArray(msg.body); //setting the information
       setIsLoading(false); //putting loading to false

--- a/views/logbook/Logbook.tsx
+++ b/views/logbook/Logbook.tsx
@@ -16,9 +16,8 @@ export function Logbook() {
 
   //message handler
   function infoViewDispatch(msg: Message) {
-    if (msg.type === MessageType.renderGoalsLegacy) {
-      //@ts-expect-error FIXME: renderGoals body is currently unknown.
-      setGoalsArray(msg.body); //setting the information
+    if (msg.type === MessageType.renderGoalsList) {
+      setGoalsArray(msg.body.goalsList); //setting the information
       setIsLoading(false); //putting loading to false
     }
   }

--- a/views/logbook/Logbook.tsx
+++ b/views/logbook/Logbook.tsx
@@ -1,4 +1,3 @@
-import objectHash from "object-hash";
 import React, { useEffect, useState } from 'react';
 
 import { GoalAnswer, PpString } from "../../lib/types";
@@ -34,13 +33,13 @@ export function Logbook() {
 
   if (!goalsArray) return null;
 
+  console.log("Logbook: goalsArray length is ", goalsArray.length);
   //when messages are loaded, we map over them and display them with the Messages component
   return (
     <div className="info-panel-container">
       <div className="info-panel">
-      {goalsArray.map((value, _) => {
-          const key = objectHash(value);
-          return <Messages key={key} answer={value} />;
+      {goalsArray.map((value, i) => {
+          return <Messages key={i} answer={value} />;
         })}
       </div>
     </div>


### PR DESCRIPTION
### Description
Adds feature toggle to show all, limited or none (default) hypotheses.
Fixes the debug panel.

### Changes
- Splits the renderGoals message type into renderGoals and renderGoalsList to allow typing them.
- Resolves #179 
- Fixes #186 
- Manually reverts #164 (This broke debug and possibly logbook functionality).

### Testing this PR
Test the different settings and check if the hypotheses are shown to the appropriate level.

### Open points

- What is the logbook supposed to show? It should be rendering the "messages", but these are empty whatever goal I inspect.
- This breaks the button transparency again1