### PR TITLE
Set tactic completions when initializing editor.

### DIFF
--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -6,6 +6,8 @@ import { CODE_PLUGIN_KEY } from "./waterproof-editor/codeview";
 // TODO: Move this to a types location.
 import { TextDocMappingMV, TextDocMappingV } from "./mapping";
 import { blocksFromMV, blocksFromV } from "./document-construction/construct-document";
+// TODO: We should be able to change the completions (on demand even?)
+import tactics from "../../shared/completions/tactics.json";
 
 /**
  * Very basic representation of the acquirable VSCodeApi.
@@ -18,6 +20,7 @@ interface VSCodeAPI {
 function createConfiguration(format: FileFormat, codeAPI: VSCodeAPI) {
 	// Create the WaterproofEditorConfig object
 	const cfg: WaterproofEditorConfig = {
+		completions: tactics,
 		api: {
 			executeHelp() {
 				codeAPI.postMessage({ type: MessageType.command, body: { command: "Help.", time: (new Date()).getTime()} });
@@ -127,9 +130,6 @@ window.onload = () => {
 				{ const diagnostics = msg.body;
 				editor.parseCoqDiagnostics(diagnostics);
 				break; }
-			case MessageType.syntax:
-				editor.initTacticCompletion(msg.body);
-				break;
 			default:
 				// If we reach this 'default' case, then we have encountered an unknown message type.
 				console.log(`[WEBVIEW] Unrecognized message type '${msg.type}'`);

--- a/editor/src/waterproof-editor/codeview/nodeview.ts
+++ b/editor/src/waterproof-editor/codeview/nodeview.ts
@@ -9,7 +9,7 @@ import {
 import { Node, Schema } from "prosemirror-model"
 import { EditorView } from "prosemirror-view"
 import { customTheme } from "./color-scheme"
-import { symbolCompletionSource, coqCompletionSource, tacticCompletionSource, renderIcon } from "../autocomplete";
+import { symbolCompletionSource, coqCompletionSource, renderIcon } from "../autocomplete";
 import { EmbeddedCodeMirrorEditor } from "../embedded-codemirror";
 import { linter, LintSource, Diagnostic, setDiagnosticsEffect, lintGutter } from "@codemirror/lint";
 import { Debouncer } from "./debouncer";
@@ -36,7 +36,8 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 		node: Node,
 		view: EditorView,
 		getPos: (() => number | undefined),
-		schema: Schema
+		schema: Schema,
+		completions: Array<Completion>
 	) {
 		super(node, view, getPos, schema);
 		this._node = node;
@@ -46,6 +47,27 @@ export class CodeBlockView extends EmbeddedCodeMirrorEditor {
 		this._lineNumberCompartment = new Compartment;
 		this._readOnlyCompartment = new Compartment;
 		this._diags = [];
+
+		// TODO: Inlined the tactic completion source.
+		// 		 We may want to be able to switch the completions on demand
+		const tacticCompletionSource: CompletionSource = function(context: CompletionContext): Promise<CompletionResult | null> {
+			return new Promise((resolve, _reject) => {
+				const before = context.matchBefore(/([^\s.\n\t\-+*])[^\s\n\t\-+*]*/gm);
+				const period = /\./gm 
+				const line = context.state.doc.lineAt(context.pos);
+				const firstletter = line.text.match(/[a-zA-Z]/);
+				const lineBeforeCursor = line.text.slice(0, context.pos - line.from);
+				
+				if ((!context.explicit && !before) || period.test(lineBeforeCursor)) resolve(null);
+				resolve({
+				// start completion instance from first letter of line
+				from: firstletter ? line.from + firstletter.index!: context.pos,
+				// non-null assertion operator "!" used to remove 'possibly null' error
+				options: completions,
+				validFor: /^[\t]*[^.]*/gm
+				})
+			});
+  		}
 
 		// Shadow this._outerView for use in the next function.
 		const outerView = this._outerView;

--- a/editor/src/waterproof-editor/editor.ts
+++ b/editor/src/waterproof-editor/editor.ts
@@ -19,7 +19,6 @@ import { MENU_PLUGIN_KEY } from "./menubar/menubar";
 import { PROGRESS_PLUGIN_KEY, progressBarPlugin } from "./progressBar";
 import { FileTranslator } from "./translation";
 import { createContextMenuHTML } from "./context-menu";
-import { initializeTacticCompletion } from "./autocomplete/tactics";
 
 // CSS imports
 import "katex/dist/katex.min.css";
@@ -245,7 +244,7 @@ export class WaterproofEditor {
 			mathPlugin,
 			realMarkdownPlugin(this._schema),
 			coqdocPlugin(this._schema),
-			codePlugin,
+			codePlugin(this._editorConfig.completions),
 			progressBarPlugin,
 			menuPlugin(this._schema, this._filef, this._userOS),
 			keymap({
@@ -455,10 +454,6 @@ export class WaterproofEditor {
 		const tr = state.tr;
 		tr.setMeta(UPDATE_STATUS_PLUGIN_KEY, status);
 		this._view.dispatch(tr);
-	}
-
-	public initTacticCompletion(useTacticsCoq: boolean) {
-		initializeTacticCompletion(useTacticsCoq);
 	}
 
 	public parseCoqDiagnostics(msg: DiagnosticMessage) {

--- a/editor/src/waterproof-editor/types.ts
+++ b/editor/src/waterproof-editor/types.ts
@@ -28,7 +28,15 @@ export abstract class WaterproofMapping {
     abstract update: (step: Step) => DocChange | WrappingDocChange;
 }
 
+export type WaterproofCompletion = {
+    label: string,
+    type: string,
+    detail: string,
+    template: string
+}
+
 export type WaterproofEditorConfig = {
+    completions: Array<WaterproofCompletion>,
     api: WaterproofCallbacks,
     documentConstructor: (document: string) => WaterproofDocument,
     mapping: new (inputString: string, versionNum: number) => WaterproofMapping

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -46,7 +46,7 @@ export type Message =
     | MessageBase<MessageType.setData, string[] | GoalAnswer<PpString> >
     | MessageBase<MessageType.setShowLineNumbers, boolean>
     | MessageBase<MessageType.setShowMenuItems, boolean>
-    | MessageBase<MessageType.syntax, boolean>
+    // | MessageBase<MessageType.syntax, boolean>
     | MessageBase<MessageType.teacher, boolean>;
 
 /**
@@ -75,7 +75,7 @@ export const enum MessageType {
     setData,
     setShowLineNumbers,
     setShowMenuItems,
-    syntax,
+    // syntax,
     teacher,
 }
 

--- a/src/pm-editor/pmWebview.ts
+++ b/src/pm-editor/pmWebview.ts
@@ -318,10 +318,11 @@ export class ProseMirrorWebview extends EventEmitter {
 
     /** Toggle the syntax mode*/
     private updateSyntaxMode() {
-        this.postMessage({
-            type: MessageType.syntax,
-            body: WaterproofConfigHelper.standardCoqSyntax
-        }, true);
+        WaterproofLogger.log("\n\n=== \nTODO: Attempting to update the used syntax. This has been disabled for the moment.\n===\n\n");
+        // this.postMessage({
+        //     type: MessageType.syntax,
+        //     body: WaterproofConfigHelper.standardCoqSyntax
+        // }, true);
     }
 
     /** Apply new doc changes to the underlying file */


### PR DESCRIPTION
### Description
The changes in this PR remove the dependency of the Waterproof Editor on the Waterproof/Coq completion sources. 

The creator of the editor is responsible for setting (and in the future updating (see #194)) the tactic completions.

Currently this change locks us into Waterproof tactic completions until we have a (partial) fix for #194.


### Changes
- The `tacticCompletionSource` has been moved into the `Nodeview`, making it initialize with a set list of completions.
- The `syntax` message type has been removed as we do not support switching the syntax at the moment.

### Testing this PR
The editor should work as expected for use with Waterproof syntax. Use the tutorial to try the Waterproof tactics completions.