### PR TITLE
Move dynamic auto completion logic into WaterproofEditor

### DIFF
--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -1,8 +1,5 @@
-import { Completion } from "@codemirror/autocomplete";
-
 import { FileFormat, Message, MessageType } from "../../shared";
 import { WaterproofEditor, WaterproofEditorConfig } from "./waterproof-editor";
-import { CODE_PLUGIN_KEY } from "./waterproof-editor/codeview";
 // TODO: Move this to a types location.
 import { TextDocMappingMV, TextDocMappingV } from "./mapping";
 import { blocksFromMV, blocksFromV } from "./document-construction/construct-document";
@@ -91,15 +88,8 @@ window.onload = () => {
 				break; }
 			case MessageType.setAutocomplete:
 				// Handle autocompletion
-				{ const state = editor.state;
-				if (!state) break;
-				const completions: Completion[] = msg.body;
-				// Apply autocomplete to all coq cells
-				CODE_PLUGIN_KEY
-					.getState(state)
-					?.activeNodeViews
-					?.forEach(codeBlock => codeBlock.handleNewComplete(completions));
-				break; }
+				editor.handleCompletions(msg.body);
+				break;
 			case MessageType.qedStatus:
 				{ const statuses = msg.body;  // one status for each input area, in order
 				editor.updateQedStatus(statuses);

--- a/editor/src/waterproof-editor/editor.ts
+++ b/editor/src/waterproof-editor/editor.ts
@@ -33,6 +33,7 @@ import { DiagnosticSeverity } from "vscode";
 import { OS } from "./osType";
 import { checkPrePost } from "./file-utils";
 import { Positioned, WaterproofMapping, WaterproofEditorConfig } from "./types";
+import { Completion } from "@codemirror/autocomplete";
 
 
 /** Type that contains a coq diagnostics object fit for use in the ProseMirror editor context. */
@@ -324,6 +325,16 @@ export class WaterproofEditor {
 			return;
 		}
 		this._editorConfig.api.lineNumbers(linenumbers, this._mapping.version);
+	}
+
+	public handleCompletions(completions: Array<Completion>) {
+		const state = this._view?.state;
+		if (!state) return;
+		// Apply autocomplete to all coq cells
+		CODE_PLUGIN_KEY
+			.getState(state)
+			?.activeNodeViews
+			?.forEach(codeBlock => codeBlock.handleNewComplete(completions));
 	}
 
 	/** Called whenever a line number message is received from vscode to update line numbers of codemirror cells */


### PR DESCRIPTION
### Description
Small PR that moves the logic of the dynamic autocompletions into the WaterproofEditor

### Testing
* Make exercises in the tutorial.
* To specifically test the dynamic autocompletion you can:
  1. Create a new Waterproof file. 
  2. Add a definition, for example: `Definition three := 3.`
  3. Enter code with the goal of referencing the definition, for example: `Check thr`, the autocomplete should show the option `three` (with type `definition`).
