### PR TITLE
Update config helper

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { TacticsPanel } from "./webviews/standardviews/tactics";
 
 import { VersionChecker } from "./version-checker";
 import { Utils } from "vscode-uri";
-import { WaterproofConfigHelper, WaterproofLogger as wpl } from "./helpers";
+import { WaterproofConfigHelper, WaterproofSetting, WaterproofLogger as wpl } from "./helpers";
 
 
 
@@ -208,9 +208,9 @@ export class Waterproof implements Disposable {
                 commands.executeCommand("workbench.action.openSettings", "waterproof.path");
             } else {
                 try {
-                    workspace.getConfiguration().update("waterproof.path", defaultValue, ConfigurationTarget.Global).then(() => {
+                    WaterproofConfigHelper.update(WaterproofSetting.Path, defaultValue, ConfigurationTarget.Global).then(() => {
                         setTimeout(() => {
-                            wpl.log("Waterproof Args setting changed to: " + WaterproofConfigHelper.path.toString());
+                            wpl.log("Waterproof Args setting changed to: " + WaterproofConfigHelper.get(WaterproofSetting.Path).toString());
                             window.showInformationMessage(`Waterproof Path setting succesfully updated!`);
                         }, 100);
                     });
@@ -231,10 +231,9 @@ export class Waterproof implements Disposable {
                 "--coqlib=/Applications/Waterproof_Background.app/Contents/Resources/lib/coq"
             ];
             try {
-                workspace.getConfiguration().update("waterproof.args", defaultArgs, ConfigurationTarget.Global).then(() => {
+                WaterproofConfigHelper.update(WaterproofSetting.Args, defaultArgs, ConfigurationTarget.Global).then(() => {
                     setTimeout(() => {
-                        wpl.log("Waterproof Args setting changed to: " + WaterproofConfigHelper.args.toString());
-
+                        wpl.log("Waterproof Args setting changed to: " + WaterproofConfigHelper.get(WaterproofSetting.Path).toString());
                         window.showInformationMessage(`Waterproof args setting succesfully updated!`);
                     }, 100);
                 });
@@ -283,8 +282,8 @@ export class Waterproof implements Disposable {
         });
 
         this.registerCommand("toggleInEditorLineNumbers", () => {
-            const updated = !WaterproofConfigHelper.showLineNumbersInEditor;
-            WaterproofConfigHelper.showLineNumbersInEditor = updated;
+            const updated = !WaterproofConfigHelper.get(WaterproofSetting.ShowLineNumbersInEditor);
+            WaterproofConfigHelper.update(WaterproofSetting.ShowLineNumbersInEditor, updated);
             window.showInformationMessage(`Waterproof: Line numbers in editor are now ${updated ? "shown" : "hidden"}.`);
         });
     }
@@ -319,9 +318,9 @@ export class Waterproof implements Disposable {
             "--coqlib=C:\\cygwin_wp\\home\\runneradmin\\.opam\\wp\\lib\\coq"
         ];
         try {
-            workspace.getConfiguration().update("waterproof.args", defaultArgs, ConfigurationTarget.Global).then(() => {
+            WaterproofConfigHelper.update(WaterproofSetting.Args, defaultArgs, ConfigurationTarget.Global).then(() => {
                 setTimeout(() => {
-                    wpl.log("Waterproof Args setting changed to: " + WaterproofConfigHelper.args.toString());
+                    wpl.log("Waterproof Args setting changed to: " + WaterproofConfigHelper.get(WaterproofSetting.Args).toString());
                 }, 100);
             });
         } catch (e) {
@@ -419,7 +418,7 @@ export class Waterproof implements Disposable {
         wpl.log("Start of initializeClient");
         
         // Whether the user has decided to skip the launch checks
-        const launchChecksDisabled = WaterproofConfigHelper.skipLaunchChecks;
+        const launchChecksDisabled = WaterproofConfigHelper.get(WaterproofSetting.SkipLaunchChecks);
 
         if (launchChecksDisabled || this._isWeb) {
             const reason = launchChecksDisabled ? "Launch checks disabled by user." : "Web extension, skipping launch checks.";
@@ -428,7 +427,7 @@ export class Waterproof implements Disposable {
             // Run the version checker.
             const requiredCoqLSPVersion = this.context.extension.packageJSON.requiredCoqLspVersion;
             const requiredCoqWaterproofVersion = this.context.extension.packageJSON.requiredCoqWaterproofVersion;
-            const versionChecker = new VersionChecker(WaterproofConfigHelper.configuration, this.context, requiredCoqLSPVersion, requiredCoqWaterproofVersion);
+            const versionChecker = new VersionChecker(this.context, requiredCoqLSPVersion, requiredCoqWaterproofVersion);
             
             // Check whether we can find coq-lsp
             const foundServer = await versionChecker.prelaunchChecks();

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -1,6 +1,101 @@
-import { workspace } from "vscode";
+import { ConfigurationTarget, workspace } from "vscode";
 import { HypVisibility } from "../../lib/types";
-import { WaterproofLogger as wpl } from "./logger";
+
+// READ THIS WHEN ADDING A NEW SETTING OR MODIFYING AN EXISTING ONE.
+// Adding a setting is done by modifying the WaterproofSetting enum underneath with the new setting name.
+// WaterproofSettingMap will then complain that it is incomplete, you should add the setting name there.
+// and then update WaterproofSettingTypes with the proper type of the setting.
+// Finally, you can use WaterproofConfigHelper.get and WaterproofConfigHelper.update to get and set the setting.
+
+/**
+ * Available settings in the `waterproof` configuration section.
+ */
+export enum WaterproofSetting {
+    TeacherMode,
+    DetailedErrorsMode,
+    ShowLineNumbersInEditor,
+    SkipLaunchChecks,
+    ShowMenuItemsInEditor,
+    EnforceCorrectNonInputArea,
+    EagerDiagnostics,
+    ShowWaterproofInfoMessages,
+    ShowNoticesAsDiagnostics,
+    MaxErrors,
+    SendDiagsExtraData,
+    GoalAfterTactic,
+    PpType,
+    VisibilityOfHypotheses,
+    TraceServer,
+    Debug,
+    Path,
+    Args,
+    AdmitOnBadQed,
+    UnicodeCompletion,
+    UpdateIgnores
+}
+
+/**
+ * Maps WaterproofSetting enum values to their string representation in the configuration.
+ */
+export const WaterproofSettingMap: Record<WaterproofSetting, string> = {
+    [WaterproofSetting.TeacherMode]: "teacherMode",
+    [WaterproofSetting.DetailedErrorsMode]: "detailedErrorsMode",
+    [WaterproofSetting.ShowLineNumbersInEditor]: "showLineNumbersInEditor",
+    [WaterproofSetting.SkipLaunchChecks]: "skipLaunchChecks",
+    [WaterproofSetting.ShowMenuItemsInEditor]: "showMenuItemsInEditor",
+    [WaterproofSetting.EnforceCorrectNonInputArea]: "enforceCorrectNonInputArea",
+    [WaterproofSetting.EagerDiagnostics]: "eager_diagnostics",
+    [WaterproofSetting.ShowWaterproofInfoMessages]: "show_waterproof_info_messages",
+    [WaterproofSetting.ShowNoticesAsDiagnostics]: "show_notices_as_diagnostics",
+    [WaterproofSetting.MaxErrors]: "max_errors",
+    [WaterproofSetting.SendDiagsExtraData]: "send_diags_extra_data",
+    [WaterproofSetting.GoalAfterTactic]: "goal_after_tactic",
+    [WaterproofSetting.PpType]: "pp_type",
+    [WaterproofSetting.VisibilityOfHypotheses]: "visibilityOfHypotheses",
+    [WaterproofSetting.TraceServer]: "trace.server",
+    [WaterproofSetting.Debug]: "debug",
+    [WaterproofSetting.Path]: "path",
+    [WaterproofSetting.Args]: "args",
+    [WaterproofSetting.AdmitOnBadQed]: "admit_on_bad_qed",
+    [WaterproofSetting.UnicodeCompletion]: "unicode_completion",
+    [WaterproofSetting.UpdateIgnores]: "updateIgnores"
+};
+
+/**
+ * Maps WaterproofSetting enum values to their types.
+ */
+type WaterproofSettingTypes = {
+    [WaterproofSetting.TeacherMode]: boolean;
+    [WaterproofSetting.DetailedErrorsMode]: boolean;
+    [WaterproofSetting.ShowLineNumbersInEditor]: boolean;
+    [WaterproofSetting.SkipLaunchChecks]: boolean;
+    [WaterproofSetting.ShowMenuItemsInEditor]: boolean;
+    [WaterproofSetting.EnforceCorrectNonInputArea]: boolean;
+    [WaterproofSetting.EagerDiagnostics]: boolean;
+    [WaterproofSetting.ShowWaterproofInfoMessages]: boolean;
+    [WaterproofSetting.ShowNoticesAsDiagnostics]: boolean;
+    [WaterproofSetting.MaxErrors]: number;
+    [WaterproofSetting.SendDiagsExtraData]: boolean;
+    [WaterproofSetting.GoalAfterTactic]: boolean;
+    [WaterproofSetting.PpType]: number;
+    [WaterproofSetting.VisibilityOfHypotheses]: HypVisibility;
+    [WaterproofSetting.TraceServer]: "off" | "messages" | "verbose";
+    [WaterproofSetting.Debug]: boolean;
+    [WaterproofSetting.Path]: string;
+    [WaterproofSetting.Args]: string[];
+    [WaterproofSetting.AdmitOnBadQed]: boolean;
+    [WaterproofSetting.UnicodeCompletion]: "off" | "normal" | "extended";
+    [WaterproofSetting.UpdateIgnores]: boolean;
+};
+
+/**
+ * Returns the fully qualified setting name for a given WaterproofSetting enum value.
+ * @param setting A setting from the WaterproofSetting enum
+ * @returns The fully qualified setting name, e.g., `waterproof.teacherMode`
+ */
+export function qualifiedSettingName(setting: WaterproofSetting): string {
+    return `waterproof.${WaterproofSettingMap[setting]}`;
+}
 
 export class WaterproofConfigHelper {
 
@@ -9,130 +104,25 @@ export class WaterproofConfigHelper {
         return config();
     }
 
-    /** `waterproof.teacherMode` */
-    static get teacherMode() {
-        return config().get<boolean>("teacherMode") as boolean;
+    /**
+     * Get the configuration with name `waterproof.[setting]`
+     * @param setting The configuration to retrieve.
+     * @returns The configuration.
+     */
+    static get<T extends WaterproofSetting>(setting: T): WaterproofSettingTypes[T]
+    {
+        return config().get<WaterproofSettingTypes[T]>(WaterproofSettingMap[setting]) as WaterproofSettingTypes[T];
     }
 
-    /** `waterproof.detailedErrorsMode` */
-    static get detailedErrors() {
-        return config().get<boolean>("detailedErrorsMode") as boolean;
+    /**
+     * Update the configuration with name `waterproof.[setting]`
+     * @param setting The configuration to update.
+     * @param value The new value.
+     * @param global Whether to update the global or workspace setting.
+     */
+    static async update<T extends WaterproofSetting>(setting: T, value: WaterproofSettingTypes[T], target: ConfigurationTarget = ConfigurationTarget.Global) {
+        return config().update(WaterproofSettingMap[setting], value, target);
     }
-
-    /** `waterproof.showLineNumbersInEditor` */
-    static get showLineNumbersInEditor() {
-        return config().get<boolean>("showLineNumbersInEditor") as boolean;
-    }
-
-    /** `waterproof.skipLaunchChecks` */
-    static get skipLaunchChecks() {
-        return config().get<boolean>("skipLaunchChecks") as boolean;
-    }
-
-    /** `waterproof.showMenuItemsInEditor` */
-    static get showMenuItems() {
-        return config().get<boolean>("showMenuItemsInEditor") as boolean;
-    }
-
-    /** `waterproof.showLineNumbersInEditor` */
-    static set showLineNumbersInEditor(value: boolean) {
-        // Update the Waterproof showLineNumbersInEditor configuration
-        // entry, true means we set the global configuration value.
-        config().update("showLineNumbersInEditor", value, true);
-    }
-
-
-    /** `waterproof.enforceCorrectNonInputArea` */
-    static get enforceCorrectNonInputArea() {
-        return config().get<boolean>("enforceCorrectNonInputArea") as boolean;
-    }
-
-    /** `waterproof.eager_diagnostics` */
-    static get eager_diagnostics() {
-        return config().get<boolean>("eager_diagnostics") as boolean;
-    }
-
-    /** `waterproof.show_waterproof_info_messages` */
-    static get show_waterproof_info_messages() {
-        return config().get<boolean>("show_waterproof_info_messages") as boolean;
-    }
-
-    /** `waterproof.show_notices_as_diagnostics` */
-    static get show_notices_as_diagnostics() {
-        return config().get<boolean>("show_notices_as_diagnostics") as boolean;
-    }
-
-    /** `waterproof.max_errors` */
-    static get max_errors() {
-        return config().get<number>("max_errors") as number;
-    }
-
-    /** `waterproof.send_diags_extra_data */
-    static get send_diags_extra_data() {
-        return config().get<boolean>("send_diags_extra_data") as boolean;
-    }
-
-    /** `waterproof.goal_after_tactic` */
-    static get goal_after_tactic() {
-        return config().get<boolean>("goal_after_tactic") as boolean;
-    }
-
-    /** `waterproof.pp_type` */
-    static get pp_type() {
-        return config().get<number>("pp_type") as number;
-    }
-
-
-    /** `waterproof.visibilityOfHypotheses` */
-    static get visibilityOfHypotheses() : HypVisibility {
-        const hypVisibility = config().get<string>("visibilityOfHypotheses");
-        wpl.log(`Hypothesis visibility set to: ${hypVisibility}`); 
-        switch(hypVisibility) {
-            case "all":
-                return HypVisibility.All;
-            case "limited":
-                return HypVisibility.Limited;
-            case "none":
-            default:
-                return HypVisibility.None;
-        }
-    }
-    /** `waterproof.trace.server` */
-    static get trace_server() {
-        return config().get<"off" | "messages" | "verbose">("trace.server") as "off" | "messages" | "verbose";
-    }
-
-    /** `waterproof.debug` */
-    static get debug() {
-        return config().get<boolean>("debug") as boolean;
-    }
-
-    /** `waterproof.path` */
-    static get path() {
-        return config().get<string>("path") as string;
-    }
-
-    /** `waterproof.args` */
-    static get args() {
-        return config().get<string[]>("args") as string[];
-    }
-
-    /** `waterproof.admit_on_bad_qed` */
-    static get admit_on_bad_qed() {
-        return config().get<boolean>("admit_on_bad_qed") as boolean;
-    }
-
-    /** `waterproof.unicode_completion` */
-    static get unicode_completion() {
-        return config().get<"off" | "normal" | "extended">("unicode_completion") as "off" | "normal" | "extended";
-    }
-
-    /** `waterproof.updateIgnores` */
-    static get updateIgnores() {
-        return config().get<boolean>("updateIgnores") as boolean;
-    }
-
-
 }
 
 function config() {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,3 @@
-export { WaterproofConfigHelper } from "./config-helper";
+export { WaterproofConfigHelper, WaterproofSetting, qualifiedSettingName } from "./config-helper";
 export { WaterproofLogger } from "./logger";
 export { WaterproofFileUtil } from "./file";

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -17,7 +17,7 @@ import { ICoqLspClient, WpDiagnostic } from "./clientTypes";
 import { determineProofStatus, getInputAreas } from "./qedStatus";
 import { convertToSimple, fileProgressNotificationType, goalRequestType } from "./requestTypes";
 import { SentenceManager } from "./sentenceManager";
-import { WaterproofConfigHelper, WaterproofLogger as wpl } from "../helpers";
+import { qualifiedSettingName, WaterproofConfigHelper, WaterproofSetting, WaterproofLogger as wpl } from "../helpers";
 
 interface TimeoutDisposable extends Disposable {
     dispose(timeout?: number): Promise<void>;
@@ -83,11 +83,11 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
             const diagnosticsCollection = languages.createDiagnosticCollection("coq");
             
             // Set detailedErrors to the value of the `Waterproof.detailedErrorsMode` setting.
-            this.detailedErrors = WaterproofConfigHelper.detailedErrors;
+            this.detailedErrors = WaterproofConfigHelper.get(WaterproofSetting.DetailedErrorsMode);
             // Update `detailedErrors` when the setting changes.
             this.disposables.push(workspace.onDidChangeConfiguration(e => {
-                if (e.affectsConfiguration("waterproof.detailedErrorsMode")) {
-                    this.detailedErrors = WaterproofConfigHelper.detailedErrors;
+                if (e.affectsConfiguration(qualifiedSettingName(WaterproofSetting.DetailedErrorsMode))) {
+                    this.detailedErrors = WaterproofConfigHelper.get(WaterproofSetting.DetailedErrorsMode);
                 }
             }));
 

--- a/src/pm-editor/pmWebview.ts
+++ b/src/pm-editor/pmWebview.ts
@@ -8,7 +8,7 @@ import { SequentialEditor } from "./edit";
 import {getFormatFromExtension, isIllegalFileName } from "./fileUtils";
 
 const SAVE_AS = "Save As";
-import { WaterproofConfigHelper, WaterproofFileUtil, WaterproofLogger } from "../helpers";
+import { qualifiedSettingName, WaterproofConfigHelper, WaterproofFileUtil, WaterproofLogger, WaterproofSetting } from "../helpers";
 import { getNonInputRegions, showRestoreMessage } from "./file-utils";
 import { CoqEditorProvider } from "./coqEditor";
 import { HistoryChangeType } from "../../shared/Messages";
@@ -38,8 +38,8 @@ export class ProseMirrorWebview extends EventEmitter {
 
     private _provider: CoqEditorProvider;
 
-    private _showLineNrsInEditor: boolean = WaterproofConfigHelper.showLineNumbersInEditor;
-    private _showMenuItemsInEditor: boolean = WaterproofConfigHelper.showMenuItems;
+    private _showLineNrsInEditor: boolean = WaterproofConfigHelper.get(WaterproofSetting.ShowLineNumbersInEditor);
+    private _showMenuItemsInEditor: boolean = WaterproofConfigHelper.get(WaterproofSetting.ShowMenuItemsInEditor);
 
     /** These regions contain the strings that are outside of the <input-area> tags, but including the tags themselves */
     private _nonInputRegions: {
@@ -102,8 +102,8 @@ export class ProseMirrorWebview extends EventEmitter {
 
         this._nonInputRegions = getNonInputRegions(doc.getText());
 
-        this._teacherMode = WaterproofConfigHelper.teacherMode;
-        this._enforceCorrectNonInputArea = WaterproofConfigHelper.enforceCorrectNonInputArea;
+        this._teacherMode = WaterproofConfigHelper.get(WaterproofSetting.TeacherMode);
+        this._enforceCorrectNonInputArea = WaterproofConfigHelper.get(WaterproofSetting.EnforceCorrectNonInputArea);
         this._lastCorrectDocString = doc.getText();
 
         const format = getFormatFromExtension(doc);
@@ -182,22 +182,22 @@ export class ProseMirrorWebview extends EventEmitter {
         }));
 
         this._disposables.push(workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration("waterproof.teacherMode")) {
+            if (e.affectsConfiguration(qualifiedSettingName(WaterproofSetting.TeacherMode))) {
                 this.updateTeacherMode();
             }
 
-            if (e.affectsConfiguration("waterproof.enforceCorrectNonInputArea")) {
-                this._enforceCorrectNonInputArea = WaterproofConfigHelper.enforceCorrectNonInputArea;
+            if (e.affectsConfiguration(qualifiedSettingName(WaterproofSetting.EnforceCorrectNonInputArea))) {
+                this._enforceCorrectNonInputArea = WaterproofConfigHelper.get(WaterproofSetting.EnforceCorrectNonInputArea);
             }
 
-            if (e.affectsConfiguration("waterproof.showLineNumbersInEditor")) {
-                this._showLineNrsInEditor = WaterproofConfigHelper.showLineNumbersInEditor;
+            if (e.affectsConfiguration(qualifiedSettingName(WaterproofSetting.ShowLineNumbersInEditor))) {
+                this._showLineNrsInEditor = WaterproofConfigHelper.get(WaterproofSetting.ShowLineNumbersInEditor);
                 this.updateLineNumberStatusInEditor();
             }
 
-            if (e.affectsConfiguration("waterproof.showMenuItemsInEditor")) {
-                this._showMenuItemsInEditor = WaterproofConfigHelper.showMenuItems;
-                WaterproofLogger.log(`Menu items will now be ${WaterproofConfigHelper.showMenuItems ? "shown" : "hidden"} in student mode`);
+            if (e.affectsConfiguration(qualifiedSettingName(WaterproofSetting.ShowMenuItemsInEditor))) {
+                this._showMenuItemsInEditor = WaterproofConfigHelper.get(WaterproofSetting.ShowMenuItemsInEditor);
+                WaterproofLogger.log(`Menu items will now be ${this._showMenuItemsInEditor ? "shown" : "hidden"} in student mode`);
                 this.updateMenuItemsInEditor();
             }
         }));
@@ -304,7 +304,7 @@ export class ProseMirrorWebview extends EventEmitter {
 
     /** Toggle the teacher mode */
     private updateTeacherMode() {
-        const mode = WaterproofConfigHelper.teacherMode;
+        const mode = WaterproofConfigHelper.get(WaterproofSetting.TeacherMode);
         this._teacherMode = mode;
         this.postMessage({
             type: MessageType.teacher,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { extensions, window, workspace } from "vscode";
+import { WaterproofConfigHelper, WaterproofSetting } from "./helpers";
 
 /**
  * Returns a random alphanumerical string of length 32.
@@ -37,13 +38,11 @@ export function checkConflictingExtensions() {
  * configuration accordingly.
  */
 export function excludeCoqFileTypes() {
-    const activationConfig = workspace.getConfiguration();
-    const updateIgnores = activationConfig.get("waterproof.updateIgnores") ?? true;
+    const updateIgnores = WaterproofConfigHelper.get(WaterproofSetting.UpdateIgnores);
     if (updateIgnores) {
-        // TODO: Look at 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const fexc : any = activationConfig.get("files.exclude");
-        activationConfig.update("files.exclude", {
+        const config = workspace.getConfiguration();
+        const fexc = config.get<object>("files.exclude") as object;
+        config.update("files.exclude", {
             "**/*.vo": true,
             "**/*.vok": true,
             "**/*.vos": true,

--- a/src/version-checker/version-checker.ts
+++ b/src/version-checker/version-checker.ts
@@ -1,7 +1,7 @@
-import { ExtensionContext, Uri, WorkspaceConfiguration, commands, env, window } from "vscode";
+import { ExtensionContext, Uri, commands, env, window } from "vscode";
 import { Version, VersionRequirement } from "./version";
 import { COMPARE_MODE } from "./types";
-import { WaterproofFileUtil, WaterproofLogger as wpl } from "../helpers";
+import { WaterproofConfigHelper, WaterproofFileUtil, WaterproofSetting, WaterproofLogger as wpl } from "../helpers";
 
 export type VersionError = {
     reason: string;
@@ -24,9 +24,9 @@ export class VersionChecker {
     private _reqVersionCoqLSP: VersionRequirement;
     private _reqVersionCoqWP: VersionRequirement;
 
-    constructor(configuration: WorkspaceConfiguration, context: ExtensionContext, coqLspVersion: string, coqWaterproofVersion: string) {
+    constructor(context: ExtensionContext, coqLspVersion: string, coqWaterproofVersion: string) {
         this._context = context;
-        this._wpPath = configuration.get<string>("path");
+        this._wpPath = WaterproofConfigHelper.get(WaterproofSetting.Path);
 
         this._reqVersionCoqLSP = VersionRequirement.fromString(coqLspVersion);
         this._reqVersionCoqWP = VersionRequirement.fromString(coqWaterproofVersion);

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -4,7 +4,7 @@ import { MessageType } from "../../../shared";
 import { IGoalsComponent } from "../../components";
 import { CoqLspClientConfig } from "../../lsp-client/clientTypes";
 import { CoqWebview } from "../coqWebview";
-import { WaterproofConfigHelper } from "../../helpers";
+import { WaterproofConfigHelper, WaterproofSetting } from "../../helpers";
 //class for panels that need Goals objects from coq-lsp
 export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
 
@@ -18,7 +18,7 @@ export abstract class GoalsBase extends CoqWebview implements IGoalsComponent {
     //sends message for renderGoals
     updateGoals(goals: GoalAnswer<PpString> | undefined) {
         if (goals) {
-            const visibility = WaterproofConfigHelper.visibilityOfHypotheses;
+            const visibility = WaterproofConfigHelper.get(WaterproofSetting.VisibilityOfHypotheses);
             this.postMessage({ type: MessageType.renderGoals, body: {goals, visibility } });
         }
     }


### PR DESCRIPTION
Create the getters and setters automatically from the settings enum, the type map and the settings mapping.

If you need the config string (`waterproof.showLineNumbersInEditor`) you can query them using `qualifiedSettingName`. This is for example used in conjunction with `affectsConfiguration`.

Resolves #203 

### Description
Short description for this Pull Request.

### Changes
Brief summary of relevant changes.

### Testing this PR
Please explain how we can test this Pull Request. 
What should we watch out for and how can we automatically test this, if possible.

