### PR TITLE
Use viewport hints to check selectively

### DIFF
--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -37,9 +37,13 @@ function createConfiguration(format: FileFormat, codeAPI: VSCodeAPI) {
 			cursorChange(cursorPosition) {
 				codeAPI.postMessage({ type: MessageType.cursorChange, body: cursorPosition });
 			},
+			viewportHint(start, end) {
+				codeAPI.postMessage({ type: MessageType.viewportHint, body: { start, end } });
+			},
 			lineNumbers(linenumbers, version) {
 				codeAPI.postMessage({ type: MessageType.lineNumbers, body: { linenumbers, version } });
 			},
+
 		},
 		documentConstructor: format === FileFormat.MarkdownV ? blocksFromMV : blocksFromV,
 		// TODO: For now assuming we are constructing an mv file editor.
@@ -125,6 +129,19 @@ window.onload = () => {
 				console.log(`[WEBVIEW] Unrecognized message type '${msg.type}'`);
 				break;
 		}
+	});
+
+	window.addEventListener('scroll', (event) => {
+		editor.handleScroll(window.scrollY, window.innerHeight);
+    console.log('Scroll Event:', event);
+    console.log('Scroll Data:', {
+        scrollX: window.scrollX,
+        scrollY: window.scrollY,
+        pageXOffset: window.pageXOffset,
+        pageYOffset: window.pageYOffset,
+        timestamp: Date.now(),
+        target: event.target
+ 	   });
 	});
 
 	// Start the editor

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -131,17 +131,8 @@ window.onload = () => {
 		}
 	});
 
-	window.addEventListener('scroll', (event) => {
-		editor.handleScroll(window.scrollY, window.innerHeight);
-    console.log('Scroll Event:', event);
-    console.log('Scroll Data:', {
-        scrollX: window.scrollX,
-        scrollY: window.scrollY,
-        pageXOffset: window.pageXOffset,
-        pageYOffset: window.pageYOffset,
-        timestamp: Date.now(),
-        target: event.target
- 	   });
+	window.addEventListener('scroll', (_event) => {
+		editor.handleScroll(window.innerHeight);
 	});
 
 	// Start the editor

--- a/editor/src/waterproof-editor/editor.ts
+++ b/editor/src/waterproof-editor/editor.ts
@@ -353,29 +353,31 @@ export class WaterproofEditor {
 		func(view.state, view.dispatch, view);
 	}
 
-	public handleScroll(scrollY: number, innerHeight: number) {
-		console.log("Enter handleScroll")
+	public handleScroll(innerHeight: number) {
 		if (!this._view) return;
-		// Use the scroll height, window height and posAtCoords to obtain
-		// the current position of the viewport
-		const viewport = {
-			top: scrollY,
-			bottom: scrollY + innerHeight
-		};
-		const posTop = this._view.posAtCoords({left: 30, top: viewport.top});
-		const posAtBottom = this._view.posAtCoords({left: 30, top: viewport.bottom});
+		const posTop = this._view.posAtCoords({left: 10, top: 10});
+		const posBottom = this._view.posAtCoords({left: 10, top: innerHeight});
+
+		if (posBottom == null || posTop == null) {
+			console.log("Invalid positions, skipping viewport hint.")
+			return;
+		}
 		
-		if (!posTop || !posAtBottom) {
-			console.log("Positions not found", posTop, posAtBottom);
+		// Get the offset before/after the node to overestimate the viewport
+		const pmOffsetStart = this._view.state.doc.resolve(posTop.pos).start()
+		const pmOffsetEnd = this._view.state.doc.resolve(posBottom.pos).end()
+
+		// Translate postions to line/offset
+		const offsetStart = this._mapping?.findPosition(pmOffsetStart);
+		const offsetEnd = this._mapping?.findPosition(pmOffsetEnd);
+
+		if (offsetStart == null || offsetEnd == null) {
+			console.log("Invalid offsets, skipping viewport hint.")
 			return;
 		}
 
-		// Translate postions to line/offset
-		const offsetStart = this._mapping?.findPosition(posTop.pos);
-		const offsetEnd = this._mapping?.findPosition(posAtBottom.pos);
-		
-		this._editorConfig.api.viewportHint(offsetStart ?? 0, offsetEnd ?? 0);
-	
+		this._editorConfig.api.viewportHint(offsetStart, offsetEnd);
+
 	}
 
 	/**

--- a/editor/src/waterproof-editor/editor.ts
+++ b/editor/src/waterproof-editor/editor.ts
@@ -211,6 +211,7 @@ export class WaterproofEditor {
 					e.preventDefault();
 				}
 			},
+			
 			handleDOMEvents: {
 				// This function will handle some DOM events before ProseMirror does.
 				// 	We use it here to cancel the 'drag' and 'drop' events, since these can
@@ -350,6 +351,30 @@ export class WaterproofEditor {
 		if (!view) return;
 		const func = type === HistoryChangeType.Undo ? undo : redo;
 		func(view.state, view.dispatch, view);
+	}
+
+	public handleScroll(scrollY: number, innerHeight: number) {
+		console.log("Enter handleScroll")
+		if (!this._view) return;
+		// Use the scroll height, window height and posAtCoords to obtain
+		// the current position of the viewport
+		const viewport = {
+			top: scrollY,
+			bottom: scrollY + innerHeight
+		};
+		const posTop = this._view.posAtCoords({left: 10, top: viewport.top});
+		const posAtBottom = this._view.posAtCoords({left: 10, top: viewport.bottom});
+		if (!posTop || !posAtBottom) {
+			console.log("Positions not found", posTop, posAtBottom);
+			return;
+		}
+		
+		// Translate postions to line/offset
+		const offsetStart = this._mapping?.findPosition(posTop.pos);
+		const offsetEnd = this._mapping?.findPosition(posAtBottom.pos);
+
+		this._editorConfig.api.viewportHint(offsetStart ?? 0, offsetEnd ?? 0);
+	
 	}
 
 	/**

--- a/editor/src/waterproof-editor/editor.ts
+++ b/editor/src/waterproof-editor/editor.ts
@@ -362,17 +362,18 @@ export class WaterproofEditor {
 			top: scrollY,
 			bottom: scrollY + innerHeight
 		};
-		const posTop = this._view.posAtCoords({left: 10, top: viewport.top});
-		const posAtBottom = this._view.posAtCoords({left: 10, top: viewport.bottom});
+		const posTop = this._view.posAtCoords({left: 30, top: viewport.top});
+		const posAtBottom = this._view.posAtCoords({left: 30, top: viewport.bottom});
+		
 		if (!posTop || !posAtBottom) {
 			console.log("Positions not found", posTop, posAtBottom);
 			return;
 		}
-		
+
 		// Translate postions to line/offset
 		const offsetStart = this._mapping?.findPosition(posTop.pos);
 		const offsetEnd = this._mapping?.findPosition(posAtBottom.pos);
-
+		
 		this._editorConfig.api.viewportHint(offsetStart ?? 0, offsetEnd ?? 0);
 	
 	}

--- a/editor/src/waterproof-editor/progressBar.ts
+++ b/editor/src/waterproof-editor/progressBar.ts
@@ -13,8 +13,8 @@ export interface IProgressPluginState {
 // Plugin key for the progress plugin
 export const PROGRESS_PLUGIN_KEY = new PluginKey<IProgressPluginState>("prosemirror-progressBar");
 
-function startSpinner(spinnerContainer: HTMLDivElement) {
-  spinnerContainer.classList.add('spinner');
+function startSpinner(_spinnerContainer: HTMLDivElement) {
+  // spinnerContainer.classList.add('spinner');
 }
 
 function stopSpinner(spinnerContainer: HTMLDivElement) {
@@ -52,7 +52,7 @@ function createProgressBar(progressState: IProgressPluginState, progressBarConta
   // Set the properties of the progress bar
   progressBar.max = endLine;
 
-  if (progressParams.progress.length > 0) {
+  if (progressParams.progress.length > 0 && startLine + 2 < endLine) {
     progressBar.value = startLine;
   } else {
     progressBar.value = endLine;
@@ -62,10 +62,11 @@ function createProgressBar(progressState: IProgressPluginState, progressBarConta
   const progressBarText = document.createElement('span');
   progressBarText.className = 'progress-bar-text';
 
-  
+  // console.log("startLine, Endline", startLine, endLine);
+
   // Set the text of the span
-  if (progressParams.progress.length > 0) {
-    progressBarText.textContent = `Verifying file, currently at line: ${startLine + 1}`;
+  if (progressParams.progress.length > 0 && startLine + 2 < endLine) {
+    progressBarText.textContent = `Verified file up to line: ${startLine + 1}`;
     startSpinner(spinnerContainer);
   } else {
     progressBarText.textContent = `File verified`;

--- a/editor/src/waterproof-editor/qedStatus.ts
+++ b/editor/src/waterproof-editor/qedStatus.ts
@@ -20,7 +20,7 @@ const statusToDecoration = (status: InputAreaStatus) => {
       return 'proven';
     case InputAreaStatus.Incomplete:
       return 'incomplete';
-    case InputAreaStatus.Invalid:
+    case InputAreaStatus.Invalid, InputAreaStatus.NotInView:
       return '';
   }
 };
@@ -42,8 +42,16 @@ const UpdateStatusPluginSpec = (editor: WaterproofEditor): PluginSpec<IUpdateSta
         if (newStatus === undefined) {
           return value;
         } else {
+          // newValues contains the values from newStatus, unless that value is NotInView,
+          // then we use the previous value
+          const newValues = newStatus.map((status : InputAreaStatus, index : number) => {
+            if (status === InputAreaStatus.NotInView) {
+              return value.status[index];
+            }
+            return status;
+          });
           return {
-            status: newStatus,
+            status: newValues,
           };
         }
       }

--- a/editor/src/waterproof-editor/types.ts
+++ b/editor/src/waterproof-editor/types.ts
@@ -18,6 +18,7 @@ export type WaterproofCallbacks = {
     applyStepError: (errorMessage: string) => void,
     cursorChange: (cursorPosition: number) => void
     lineNumbers: (linenumbers: Array<number>, version: number) => void,
+    viewportHint: (start: number, end: number) => void,
 }
 
 export abstract class WaterproofMapping {

--- a/package.json
+++ b/package.json
@@ -372,6 +372,11 @@
             "type": "boolean",
             "default": true,
             "description": "Send extra diagnostics data, usually on error"
+          },
+          "waterproof.ContinuousChecking": {
+            "type": "boolean",
+            "default": false,
+            "description": "By default, Waterproof only checks the part of the document that is visble. Turning this setting on will check the whole document continuously. Turning this on may cause performance issues."
           }
         }
       },

--- a/shared/InputAreaStatus.ts
+++ b/shared/InputAreaStatus.ts
@@ -8,4 +8,6 @@ export enum InputAreaStatus {
     Incomplete = "incomplete",
     /** The input area does not contain `Qed.` at the end, so the status cannot be determined. */
     Invalid = "invalid",
+    /** Not in view, so was not requested */
+    NotInView = "not-in-view",
 }

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -46,7 +46,8 @@ export type Message =
     | MessageBase<MessageType.setData, string[] | GoalAnswer<PpString> >
     | MessageBase<MessageType.setShowLineNumbers, boolean>
     | MessageBase<MessageType.setShowMenuItems, boolean>
-    | MessageBase<MessageType.teacher, boolean>;
+    | MessageBase<MessageType.teacher, boolean>
+    | MessageBase<MessageType.viewportHint, { start: number, end: number }>;
 
 /**
  * Message type enum. Every message that is send from the
@@ -76,6 +77,7 @@ export const enum MessageType {
     setShowMenuItems,
     teacher,
     flash,
+    viewportHint,
 }
 
 export const enum HistoryChangeType {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,10 @@ export class Waterproof implements Disposable {
         this.webviewManager.on(WebviewManagerEvents.editorReady, (document: TextDocument) => {
             this.client.updateCompletions(document);
         });
+        this.webviewManager.on(WebviewManagerEvents.viewportHint, ({document, start, end}) => {
+            this.client.sendViewportHint(document, start, end);
+        });
+
         this.webviewManager.on(WebviewManagerEvents.focus, async (document: TextDocument) => {
             wpl.log("Focus event received");
 

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -72,6 +72,12 @@ export class WaterproofConfigHelper {
         return config().get<boolean>("send_diags_extra_data") as boolean;
     }
 
+    /** `waterproof.ContinuousChecking` */
+    static get ContinuousChecking() {
+        return config().get<boolean>("ContinuousChecking") as boolean;
+    }
+
+
     /** `waterproof.goal_after_tactic` */
     static get goal_after_tactic() {
         return config().get<boolean>("goal_after_tactic") as boolean;

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -211,7 +211,6 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
         }
 
         async requestGoals(params?: GoalRequest | Position): Promise<GoalAnswer<PpString>> {
-            wpl.debug(`Requesting goals with params: ${JSON.stringify(params)}`);
             if (!params || "line" in params) {  // if `params` is not a `GoalRequest` ...
                 params ??= this.activeCursorPosition;
                 if (!this.activeDocument || !params) {
@@ -257,7 +256,6 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
 
         async sendViewportHint(document: TextDocument, start: number, end: number): Promise<void> {
             if (!this.isRunning()) return;
-            console.log("Document", document);
             const startPos = document.positionAt(start);
             let endPos = document.positionAt(end);
             // Compute end of document position, use that if we're close
@@ -266,7 +264,6 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
                 endPos = endOfDocument;
             }
 
-            console.log("Start line, end line", startPos.line, endPos.line);
             const requestBody = {
                 'textDocument':  VersionedTextDocumentIdentifier.create(
                     document.uri.toString(),
@@ -283,7 +280,6 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
                     }
                 } 
             };
-            console.log("Viewrange with body", requestBody);
             
             await this.sendNotification("coq/viewRange", requestBody);
 

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -5,6 +5,7 @@ import {
     LanguageClientOptions,
     LogTraceNotification,
     Middleware,
+    Range,
     SymbolInformation,
     VersionedTextDocumentIdentifier
 } from "vscode-languageclient";
@@ -278,6 +279,34 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
             }
         }
 
+        async sendViewportHint(document: TextDocument, start: number, end: number): Promise<void> {
+            if (!this.isRunning()) return;
+            console.log("Document", document);
+            const startPos = document.positionAt(start);
+            const endPos = document.positionAt(end);
+            const requestBody = {
+                'textDocument':  VersionedTextDocumentIdentifier.create(
+                    document.uri.toString(),
+                    document.version
+                ),
+                'range': ({
+                    start: {
+                        line: startPos.line,
+                        character: startPos.character
+                    },
+                    end: {
+                        line: endPos.line,
+                        character: endPos.character
+                    }
+                } as Range)
+            };
+            console.log("Viewrange with body", requestBody);
+            
+            this.sendNotification("coq/viewRange", requestBody);
+
+
+        }
+
         async updateCompletions(document: TextDocument): Promise<void> {
             if (!this.isRunning()) return;
             if (!this.webviewManager?.has(document)) {
@@ -311,8 +340,6 @@ export function CoqLspClient<T extends ClientConstructor>(Base: T) {
             this.fileProgressComponents.forEach(c => c.dispose());
             this.disposables.forEach(d => d.dispose());
             return super.dispose(timeout);
-        }
-
     }
 }
 
@@ -321,4 +348,5 @@ function wasCanceledByServer(reason: unknown): boolean {
         && typeof reason === "object"
         && "message" in reason
         && reason.message === "Request got old in server";  // or: code == -32802
+}
 }

--- a/src/lsp-client/clientTypes.ts
+++ b/src/lsp-client/clientTypes.ts
@@ -68,6 +68,8 @@ export interface ICoqLspClient {
     /** Sends an LSP request to retrieve the symbols in the `activeDocument`. */
     requestSymbols(): Promise<DocumentSymbol[]>;
 
+    sendViewportHint(document: TextDocument, start: number, end: number): Promise<void>;
+
     /**
      * Requests symbols and sends corresponding completions to the editor.
      */
@@ -129,6 +131,7 @@ export interface CoqLspServerConfig {
     pp_type: 0 | 1 | 2;
     show_stats_on_hover: boolean;
     send_diags_extra_data: boolean;
+    check_only_on_request: boolean;
 }
 
 // TODO: Rewrite namespace to modern syntax
@@ -152,6 +155,7 @@ export namespace CoqLspServerConfig {
             pp_type: wsConfig.pp_type,
             show_stats_on_hover: wsConfig.show_stats_on_hover,
             send_diags_extra_data: wsConfig.send_diags_extra_data,
+            check_only_on_request: true
         };
     }
 }

--- a/src/lsp-client/clientTypes.ts
+++ b/src/lsp-client/clientTypes.ts
@@ -4,6 +4,7 @@ import { BaseLanguageClient, DocumentSymbol, LanguageClientOptions } from "vscod
 import { GoalAnswer, GoalRequest, PpString } from "../../lib/types";
 import { WebviewManager } from "../webviewManager";
 import { SentenceManager } from "./sentenceManager";
+import { WaterproofConfigHelper } from "../helpers";
 
 /**
  * The following are types related to the language client and the
@@ -155,7 +156,7 @@ export namespace CoqLspServerConfig {
             pp_type: wsConfig.pp_type,
             show_stats_on_hover: wsConfig.show_stats_on_hover,
             send_diags_extra_data: wsConfig.send_diags_extra_data,
-            check_only_on_request: true
+            check_only_on_request: !wsConfig.check_only_on_request
         };
     }
 }

--- a/src/pm-editor/pmWebview.ts
+++ b/src/pm-editor/pmWebview.ts
@@ -408,9 +408,6 @@ export class ProseMirrorWebview extends EventEmitter {
                 this._linenumber = msg.body;
                 this.updateLineNumbers();
                 break;
-            case MessageType.viewportHint:
-                console.log("Received viewport hint:", msg.body);
-            // eslint-disable-next-line no-fallthrough
             default:
                 this.emit(WebviewEvents.message, msg);
                 break;

--- a/src/pm-editor/pmWebview.ts
+++ b/src/pm-editor/pmWebview.ts
@@ -240,7 +240,6 @@ export class ProseMirrorWebview extends EventEmitter {
             <title>ProseMirror Math</title>
             <meta charset="utf-8">
             <script defer src="${scriptUri}" nonce="${nonce}"></script><link href="${styleUri}" rel="stylesheet">
-            </script>
         </head>
         <body>
             <article>

--- a/src/pm-editor/pmWebview.ts
+++ b/src/pm-editor/pmWebview.ts
@@ -240,6 +240,7 @@ export class ProseMirrorWebview extends EventEmitter {
             <title>ProseMirror Math</title>
             <meta charset="utf-8">
             <script defer src="${scriptUri}" nonce="${nonce}"></script><link href="${styleUri}" rel="stylesheet">
+            </script>
         </head>
         <body>
             <article>
@@ -407,6 +408,9 @@ export class ProseMirrorWebview extends EventEmitter {
                 this._linenumber = msg.body;
                 this.updateLineNumbers();
                 break;
+            case MessageType.viewportHint:
+                console.log("Received viewport hint:", msg.body);
+            // eslint-disable-next-line no-fallthrough
             default:
                 this.emit(WebviewEvents.message, msg);
                 break;

--- a/src/webviewManager.ts
+++ b/src/webviewManager.ts
@@ -13,6 +13,7 @@ export enum WebviewManagerEvents {
     command         = "command",
     updateButton    = "updateButton",
     buttonClick     = "buttonClick",
+    viewportHint    = "viewportHint",
 }
 
 /**
@@ -265,6 +266,9 @@ export class WebviewManager extends EventEmitter {
                 // We intercept the `command` type message here, since it can be fired from within the editor (rmb -> Help)
                 this.onToolsMessage("help", {type: MessageType.command, body: { command: "createHelp" }});
                 setTimeout(() => this.onToolsMessage("help", {type: MessageType.command, body: { command: "Help." }}), 250);
+                break;
+            case MessageType.viewportHint:
+                this.emit(WebviewManagerEvents.viewportHint, {document, ...message.body});
                 break;
             default:
                 console.error(`Unrecognized message type ${message.type}, not handled by webview manager`);


### PR DESCRIPTION
### Description
Communicate to the LSP what part of the document we're viewing so it only computes what is necessary.
Slight decrease in performance for the use case "open document, scroll down relatively slowly"
Increase in responsiveness for basically any other situation.

### Changes
- Start LSP with check_only_on_request
- Uses "coq/viewRange" notifications to signal the viewport
- Disables the spinner in the progress bar
- Updates language in progress bar to be more neutral and not suggest it's working on something
- Query the LSP to render decorations in the view.

### Testing this PR
Open up documents, try edits at the beginning and the end, and anything that has caused problems in the past with respect to progress/decorations.

TODO:

- [ ] Properly disable spinner

