### PR TITLE
Update installer versions (and remove command line arguments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Within a WSL distribution, execute the following lines:
 sudo apt-get install opam
 opam init
 eval $(opam env)
-opam install coq-lsp.0.2.2+8.17
+opam install coq-lsp.0.2.3+9.0
 opam install coq-waterproof
 ```
 
@@ -100,7 +100,7 @@ In a terminal, execute the following lines
 apt-get install opam
 opam init
 eval $(opam env)
-opam install coq-lsp.0.2.2+8.17
+opam install coq-lsp.0.2.3+9.0
 opam install coq-waterproof
 ```
 
@@ -131,7 +131,7 @@ Then execute
 ```
 opam init
 eval $(opam env)
-opam install coq-lsp.0.2.2+8.17
+opam install coq-lsp.0.2.3+9.0
 opam install coq-waterproof
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Waterproof",
   "description": "Waterproof for VSC",
   "version": "0.9.18",
-  "requiredCoqLspVersion": ">=0.2.2",
+  "requiredCoqLspVersion": ">=0.2.3",
   "requiredCoqWaterproofVersion": ">=3.0.0",
   "contributors": [
     "Collin Harcarik <collin@plutode.com>",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ export class Waterproof implements Disposable {
                 this.client.activeCursorPosition = undefined;
                 this.webviewManager.open("goals");
                 for (const g of this.goalsComponents) g.updateGoals(undefined);
-    
+
             }
 
         });
@@ -197,7 +197,7 @@ export class Waterproof implements Disposable {
                 case "openbsd": defaultValue = undefined; break;
                 case "sunos": defaultValue = undefined; break;
                 // WINDOWS
-                case "win32": defaultValue = "C:\\cygwin_wp\\home\\runneradmin\\.opam\\wp\\bin\\coq-lsp.exe"; break;
+                case "win32": defaultValue = "C:\\waterproof_dependencies\\opam\\wp-3.0.0+9.0\\bin\\coq-lsp.exe"; break;
                 case "cygwin": defaultValue = undefined; break;
                 case "netbsd": defaultValue = undefined; break;
             }
@@ -217,7 +217,8 @@ export class Waterproof implements Disposable {
                 }
             }
         });
-        this.registerCommand("setDefaultArgsWin", () => this.setDefaultArgsWin());
+        // No longer necessary
+        //this.registerCommand("setDefaultArgsWin", () => this.setDefaultArgsWin());
 
         this.registerCommand("defaultArgsMac", () => {
             // If we are not on a mac platform, this is a no-op.
@@ -245,8 +246,9 @@ export class Waterproof implements Disposable {
             commands.executeCommand(`waterproof.defaultPath`);
             commands.executeCommand(`waterproof.setDefaultArgsWin`);
 
-            const windowsInstallationScript = `echo Begin Waterproof Installation && echo Downloading installer ... && curl -o Waterproof_Installer.exe -L https://github.com/impermeable/waterproof-dependencies-installer/releases/download/v2.2.0%2B8.17/Waterproof-dependencies-installer-v2.2.0+8.17.exe && echo Installer Finished Downloading - Please wait for the Installer to execute, this can take up to a few minutes && Waterproof_Installer.exe && echo Required Files Installed && del Waterproof_Installer.exe && echo COMPLETE - The Waterproof checker will restart automatically a few seconds after this terminal is closed`
-            const uninstallerLocation = `C:\\cygwin_wp\\home\\runneradmin\\.opam\\wp\\Uninstall.exe`
+            const windowsInstallationScript = `echo Begin Waterproof dependency software installation && echo Downloading installer ... && curl -o Waterproof_Installer.exe -L https://github.com/impermeable/waterproof-dependencies-installer/releases/download/wp-3.0.0%2B9.0/Waterproof-dependencies-wp-3.0.0+9.0-Windows-x86_64.exe && echo Installer Finished Downloading - Please wait for the Installer to execute, this can take up to a few minutes && Waterproof_Installer.exe && echo Required Files Installed && del Waterproof_Installer.exe && echo COMPLETE - The Waterproof checker will restart automatically a few seconds after this terminal is closed`
+            // TODO: this may need to be determined in a better way
+            const uninstallerLocation = `C:\\waterproof_dependencies\\.opam\\wp-3.0.0+9.0\\Uninstall.exe`
 
             await this.stopClient();
 
@@ -342,11 +344,11 @@ export class Waterproof implements Disposable {
                         // Open the file using the waterproof editor
                         // TODO: Hardcoded `coqEditor.coqEditor`.
                         commands.executeCommand("vscode.openWith", uri, "coqEditor.coqEditor");
-                    });                    
+                    });
                 }, (err) => {
                     window.showErrorMessage("Could not a new Waterproof file.");
                     console.error(`Could not read Waterproof tutorial file: ${err}`);
-                    return;                   
+                    return;
                 })
         });
     }
@@ -371,11 +373,11 @@ export class Waterproof implements Disposable {
                         // Open the file using the waterproof editor
                         // TODO: Hardcoded `coqEditor.coqEditor`.
                         commands.executeCommand("vscode.openWith", uri, "coqEditor.coqEditor");
-                    });                    
+                    });
                 }, (err) => {
                     window.showErrorMessage("Could not create a new Waterproof file.");
                     console.error(`Could not read Waterproof tutorial file: ${err}`);
-                    return;                   
+                    return;
                 })
         });
     }
@@ -415,7 +417,7 @@ export class Waterproof implements Disposable {
      */
     async initializeClient(): Promise<void> {
         wpl.log("Start of initializeClient");
-        
+
         // Whether the user has decided to skip the launch checks
         const launchChecksDisabled = WaterproofConfigHelper.skipLaunchChecks;
 
@@ -427,7 +429,7 @@ export class Waterproof implements Disposable {
             const requiredCoqLSPVersion = this.context.extension.packageJSON.requiredCoqLspVersion;
             const requiredCoqWaterproofVersion = this.context.extension.packageJSON.requiredCoqWaterproofVersion;
             const versionChecker = new VersionChecker(WaterproofConfigHelper.configuration, this.context, requiredCoqLSPVersion, requiredCoqWaterproofVersion);
-            
+
             // Check whether we can find coq-lsp
             const foundServer = await versionChecker.prelaunchChecks();
             if (foundServer) {
@@ -472,7 +474,7 @@ export class Waterproof implements Disposable {
                 throw reason;  // keep chain rejected
             }
         );
-        
+
     }
 
     /**
@@ -513,7 +515,7 @@ export class Waterproof implements Disposable {
      * This function gets called on TextEditorSelectionChange events and it requests the goals
      * if needed
      */
-    private async updateGoals(document: TextDocument, position: Position): Promise<void> {  
+    private async updateGoals(document: TextDocument, position: Position): Promise<void> {
         wpl.debug(`Updating goals for document: ${document.uri.toString()} at position: ${position.line}:${position.character}`);
         if (!this.client.isRunning()) {
             wpl.debug("Client is not running, cannot update goals.");

--- a/walkthrough-data/initial-setup/change-setting-path-windows.md
+++ b/walkthrough-data/initial-setup/change-setting-path-windows.md
@@ -1,3 +1,3 @@
 # Change the `Waterproof.Path` setting
 If you did not change any default values when running the Waterproof installer from the previous step then the value for the setting should be
-```C:\cygwin_wp\home\runneradmin\.opam\wp\bin\coq-lsp.exe```
+```C:\waterproof_dependencies\opam\wp-3.0.0+9.0\bin\coq-lsp.exe```

--- a/walkthrough-data/initial-setup/installation-without-installer.md
+++ b/walkthrough-data/initial-setup/installation-without-installer.md
@@ -4,8 +4,8 @@
 apt-get install opam
 opam init
 eval $(opam env)
-opam install coq-lsp.0.2.2+8.17
-opam install coq-waterproof.2.2.0+8.17
+opam install coq-lsp.0.2.3+9.0
+opam install coq-waterproof
 ```
 
 If vscode cannot detect the installation, set the coq-lsp path to the output of `which coq-lsp`. This can be done


### PR DESCRIPTION
### Description
Updates the installer link to the version for wp-3.0.0+9.0

### Changes
- Installer link updated
- Default command line arguments are no longer necessary on windows

### Testing this PR
- Build the extension with `npm run package`
- Get the `.vsix` file from the test_out folder
- Use this file in `install extension from .vsix` in vscode
- Uninstall a previous version of the Waterproof dependency software (although it is in a different spot, so it shouldn't matter much)
- Try to open a folder with waterproof `.mv` files in vscode
- A popup should appear, choose for automatic installation
- After the installation, after restarting the extension, waterproof should work.

