### PR TITLE
Update styling of inline code in Waterproof Theme

### DIFF
--- a/editor/src/waterproof-editor/styles/markdown.css
+++ b/editor/src/waterproof-editor/styles/markdown.css
@@ -26,6 +26,12 @@
     padding: 0.2em;
 }
 
+
+/* Styles the inline code parts of the markdown cells */
+code {
+    font-family: var(--wp-editor-font-family);
+}
+
 /* 
 .markdown-view-editor::after {
     border-top: 1px solid black;

--- a/themes/waterproofTheme-color-theme-light.json
+++ b/themes/waterproofTheme-color-theme-light.json
@@ -304,7 +304,7 @@
         "walkThrough.embeddedEditorBackground": "#eceeff",
         "textLink.foreground": "#6183bb",
         "textLink.activeForeground": "#7dcfff",
-        "textPreformat.foreground": "#9699a8",
+        "textPreformat.foreground": "#56585e",
         "textBlockQuote.background": "#eceeff",
         "textCodeBlock.background": "#aab0d3",
         "textSeparator.foreground": "#363b54",

--- a/themes/waterproofTheme-color-theme-light.json
+++ b/themes/waterproofTheme-color-theme-light.json
@@ -304,7 +304,7 @@
         "walkThrough.embeddedEditorBackground": "#eceeff",
         "textLink.foreground": "#6183bb",
         "textLink.activeForeground": "#7dcfff",
-        "textPreformat.foreground": "#56585e",
+        "textPreformat.foreground": "#000000",
         "textBlockQuote.background": "#eceeff",
         "textCodeBlock.background": "#aab0d3",
         "textSeparator.foreground": "#363b54",


### PR DESCRIPTION
### Description 

Change the styling of the inline code from
<img width="815" height="102" alt="image" src="https://github.com/user-attachments/assets/30f8a8b2-b32b-4818-b80e-cbe3f0ca9371" />
to
<img width="815" height="102" alt="image" src="https://github.com/user-attachments/assets/62e0abe0-56d5-41af-81e5-0d4302394b15" />


Resolves #205 

### Changes

Relevant styling property is `textPreformat.foreground`, this can still be changed to a darker shade of gray.