### PR TITLE
Fix colouring of dropdowns in Waterproof theme

### DIFF
--- a/themes/waterproofTheme-color-theme-light.json
+++ b/themes/waterproofTheme-color-theme-light.json
@@ -80,7 +80,7 @@
 
         "dropdown.foreground": "#787c99",
         "dropdown.background": "#ffffff",
-        "dropdown.listBackground": "#14141b",
+        "dropdown.listBackground": "#ffffff",
 
         "activityBar.background": "#2b3990",
         "activityBar.foreground": "#ffffff",


### PR DESCRIPTION
### Description
Fixes the colouring of dropdowns in the Waterproof light theme, making unselected options readable.


### Changes
Changed the `dropdown.listBackground` property to be white.

### Testing this PR
Load the extension and find some dropdown in the extension. For example, in the Waterproof configuration `ppType` spawns a dropdown.
