### PR TITLE
Enable sonar support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Disable shallow clone for sonar
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
@@ -30,4 +32,8 @@ jobs:
       run: npm ci
 
     - name: Run Unit Tests
-      run: npm run unit-tests
+      run: npm run unit-tests-cov
+    - name: SonarQube Scan
+      uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # pinned v6
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __tests_output__/
 **/*.cache
 ExampleFiles/
 /cypress/screenshots/
+coverage/

--- a/package.json
+++ b/package.json
@@ -531,6 +531,7 @@
     "package": "npm run clean && npm run test-package",
     "package-pre-release": "npm run clean && npm run test-pre-release",
     "unit-tests": "npx jest",
+    "unit-tests-cov": "npx jest --coverage",
     "lezer-generator": "npx lezer-generator ./editor/src/waterproof-editor/codeview/lang-pack/syntax.grammar -o ./editor/src/waterproof-editor/codeview/lang-pack/syntax.ts",
     "cypress-tests": "npx cypress run",
     "lint": "npx eslint .",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=impermeable_waterproof-vscode
+sonar.organization=impermeable
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=waterproof-vscode
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
### Description
Connects this repository to SonarCloud

### Changes
- Runs CI unit tests with coverage and then calls sonar scanner

### Testing this PR
Check the report [here](https://sonarcloud.io/summary/new_code?id=impermeable_waterproof-vscode&pullRequest=245). There is not supposed to be any coverage data, because this PR does not touch any code.

