### PR TITLE
Add correct abs symbol plus alias

### DIFF
--- a/completions/symbols.json
+++ b/completions/symbols.json
@@ -350,8 +350,14 @@
     {
         "label": "\\abs",
         "type": "symbol",
-        "apply": "∣",
+        "apply": "｜",
         "symbolPanelCategory": 2
+    },
+    {
+        "label": "\\vert",
+        "type": "symbol",
+        "apply": "｜",
+        "symbolPanelCategory": 99
     },
     {
         "label": "\\intersection",


### PR DESCRIPTION
In `waterproof-exercises/ch5_sequences_sum_rule.mv` we make use of unicode symbol `｜` (U+FF5C) for absolute value notation.
The current symbol in the symbols.json file is `∣` (U+2223) which does not work with the new notation (`|`, the pipe character, however does also work).