### PR TITLE
Lean documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The Waterproof vscode extension helps students learn how to write mathematical p
     c. [Manual installation on Windows with installer](#manual-installation-on-windows-with-installer)
 
     d. [Manual installation on Windows with WSL](#manual-installation-on-windows-with-wsl)
-3. [Getting Started](#getting-started)
+3. [Optional dependencies for (Verbose) Lean](#optional-dependencies)
+4. [Getting Started](#getting-started)
 
 # Automatic installation instructions for Windows
 
@@ -153,6 +154,14 @@ Alternatively, one navigate to a folder in WSL itself, and type `code .` to open
 ### Step 4: Install this [Waterproof vscode extension](https://marketplace.visualstudio.com/items?itemName=waterproof-tue.waterproof)
 
 From this page in vscode, you can just click on the "Install" button.
+
+# Optional dependencies
+
+If you want to use the (Verbose) Lean functionality in Waterproof, you will need to have `elan` installed,
+which will automatically install the right dependencies.
+You can do this by following the instructions [here](https://lean-lang.org/install/).
+
+
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ From this page in vscode, you can just click on the "Install" button.
 If you want to use the (Verbose) Lean functionality in Waterproof, you will need to have `elan` installed,
 which will automatically install the right dependencies.
 You can do this by following the instructions [here](https://lean-lang.org/install/).
+Note: You can currently only use Lean files that use the [Waterproof Genre](https://github.com/impermeable/waterproof-editor/pull/81).
 
 
 


### PR DESCRIPTION
Documents the Lean installation step.

I chose to do this in the place where the Rocq stuff is also mentioned, but this README does fulfill a double role, also being for end-users. My proposal is that we re-evaluate the documentation after we look at the Lean installation story.

Fixes #293 
