### PR TITLE
Don't show multilean tags in editor

### DIFF
--- a/__tests__/prosedoc-construction/top-level-construction.test.ts
+++ b/__tests__/prosedoc-construction/top-level-construction.test.ts
@@ -182,30 +182,30 @@ Goal True.
 
 test("Parse top level blocks (Lean)", () => {
     const blocks = topLevelBlocksLean(inputDocumentLean);
-    expect(blocks.length).toBe(10);
+    expect(blocks.length).toBe(8);
 
-    const [preamble, md1, nl1, code, nl2, input, nl3, md2, math, md3] = blocks;
+    const [preamble, md1, code, nl2, input, md2, math, md3] = blocks;
 
     expect(typeguards.isHintBlock(preamble)).toBe(true);
     expect(preamble.stringContent).toBe("import Some.Library\n#doc (Genre) \"Title\" =>\n");
 
+    // TODO: After we have come up with a solution for the multilean tags,
+    // we should check the \n here very carefully.
     expect(typeguards.isMarkdownBlock(md1)).toBe(true);
-    expect(md1.stringContent).toBe("# A Header\n::::multilean")
-
-    expect(typeguards.isNewlineBlock(nl1)).toBe(true);
+    expect(md1.stringContent).toBe("# A Header\n");
 
     expect(typeguards.isCodeBlock(code)).toBe(true);
-    expect(code.stringContent).toBe("def fortyTwo :=\n  30 +")
+    expect(code.stringContent).toBe("def fortyTwo :=\n  30 +");
 
     expect(typeguards.isNewlineBlock(nl2)).toBe(true);
 
     expect(typeguards.isInputAreaBlock(input)).toBe(true);
     expect(input.stringContent).toBe("```lean\n  12\n```");
 
-    expect(typeguards.isNewlineBlock(nl3)).toBe(true);
-
+    // TODO: After we have come up with a solution for the multilean tags,
+    // we should check the \n here very carefully.
     expect(typeguards.isMarkdownBlock(md2)).toBe(true);
-    expect(md2.stringContent).toBe("::::\n## Markdown Content\n");
+    expect(md2.stringContent).toBe("\n## Markdown Content\n");
 
     expect(typeguards.isMathDisplayBlock(math)).toBe(true);
     expect(math.stringContent).toBe("x^2 + y = z");
@@ -215,9 +215,31 @@ test("Parse top level blocks (Lean)", () => {
         .toBe("\nA list:\n  1. *Italicized* text\n  2. $`y = z - x^2`\n");
 })
 
+// TODO: The serialization logic should account for the multilean tags, which it doesnt at the moment.
 test("Parse and serialize document (Lean)", () => {
     const doc = constructDocument(topLevelBlocksLean(inputDocumentLean));
     const out = new LeanSerializer().serializeDocument(doc);
 
-    expect(out).toBe(inputDocumentLean);
+    const outputDocumentLean = `import Some.Library
+#doc (Genre) "Title" =>
+# A Header
+\`\`\`lean
+def fortyTwo :=
+  30 +
+\`\`\`
+:::input
+\`\`\`lean
+  12
+\`\`\`
+:::
+## Markdown Content
+$$\`x^2 + y = z\`
+A list:
+  1. *Italicized* text
+  2. $\`y = z - x^2\`
+`;
+
+    // We would want this operation to be the identity, i.e.
+    // expect(out).toBe(inputDocumentLean);
+    expect(out).toBe(outputDocumentLean);
 })


### PR DESCRIPTION
Change lean document constructor to make `::::multilean` and `::::` not appear in the editor for now.

Resolves #305 
