### PR TITLE
Fix for Goals Panel not re-opening, as per Issue #149

### DIFF
--- a/src/webviews/coqWebview.ts
+++ b/src/webviews/coqWebview.ts
@@ -217,6 +217,8 @@ export abstract class CoqWebview extends EventEmitter implements Disposable {
      * @returns boolean on whether message was sent successfully
      */
     public postMessage(msg: Message) : boolean {
+        if (!this._panel) return false;
+
         if (this.state != WebviewState.visible) {
             this.changeState(WebviewState.visible);
         }


### PR DESCRIPTION
### Description
Fix for Issue #149, which caused the goals panel to not opening after a cursor changes occurred while it was closed.
### Changes
Before setting the webview state of the (goals) panel to visible, it first checks that this panel exists. This ensures that the panel is not mistaken for being visible when it isn't.
### Testing this PR
Use the same steps to reproduce Issue #149, the goals panel should open reliably instead.

