### PR TITLE
Busy indicator

### DIFF
--- a/developer-resources/messages.md
+++ b/developer-resources/messages.md
@@ -97,6 +97,18 @@ This message does not have a body.
 errorGoals
 ```
 
+### `executionInfo`
+#### Description
+Sent by the extension to the editor to indicate the range of the sentence currently being checked by the language server. Used to display a busy indicator at the relevant position in the editor.
+
+#### Body
+```ts
+{
+    from: number, // Start offset of the sentence being executed
+    to: number    // End offset of the sentence being executed
+}
+```
+
 ### `init`
 
 #### Description

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -186,7 +186,14 @@ window.onload = () => {
 			case MessageType.progress:
 				{
 					const progressParams = msg.body;
-					editor.updateProgressBar(progressParams);
+					editor.updateProgressBar(progressParams);					if (progressParams.progress.length === 0) {
+						editor.removeBusyIndicators();
+					}					break;
+			}
+			case MessageType.executionInfo:
+				{
+					const range = msg.body;
+					editor.setBusyIndicator(range.from);
 					break;
 				}
 			case MessageType.diagnostics:

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -187,10 +187,12 @@ window.onload = () => {
 			case MessageType.progress:
 				{
 					const progressParams = msg.body;
-					editor.updateProgressBar(progressParams);					if (progressParams.progress.length === 0) {
+					editor.updateProgressBar(progressParams);					
+					if (progressParams.progress.length === 0) {
 						editor.removeBusyIndicators();
-					}					break;
-			}
+					}					
+					break;
+				}
 			case MessageType.executionInfo:
 				{
 					const range = msg.body;

--- a/package.json
+++ b/package.json
@@ -298,6 +298,11 @@
             "type": "boolean",
             "default": false,
             "description": "Enables the menu items in the editor. Using these buttons you can add text, code and latex cells in input areas."
+          },
+          "waterproof.sendExecInfo": {
+            "type": "boolean",
+            "default": true,
+            "description": "Send execution information to the editor to show a busy indicator on the line currently being checked."
           }
         }
       },

--- a/shared/Messages.ts
+++ b/shared/Messages.ts
@@ -30,6 +30,7 @@ export type Message =
     | MessageBase<MessageType.editorHistoryChange, HistoryChange>
     | MessageBase<MessageType.editorReady>
     | MessageBase<MessageType.errorGoals, unknown>
+    | MessageBase<MessageType.executionInfo, { from: number, to: number }>
     | MessageBase<MessageType.init, { value: string, version: number }>
     | MessageBase<MessageType.insert, { symbolUnicode: string, type: "symbol" | "tactics", time: number }>
     | MessageBase<MessageType.replaceRange, { start: number, end: number, text: string }>
@@ -65,6 +66,8 @@ export const enum MessageType {
     editorHistoryChange,
     editorReady,
     errorGoals,
+    executionInfo,
+    flash,
     init,
     insert,
     replaceRange,
@@ -81,7 +84,6 @@ export const enum MessageType {
     setShowMenuItems,
     teacher,
     themeUpdate,
-    flash,
     viewportHint,
     infoviewRpc
 }

--- a/src/helpers/config-helper.ts
+++ b/src/helpers/config-helper.ts
@@ -36,6 +36,7 @@ export enum WaterproofSetting {
     UpdateIgnores,
     ContinuousChecking,
     LogDebugStatements,
+    SendExecInfo,
 }
 
 /**
@@ -67,6 +68,7 @@ export const WaterproofSettingMap: Record<WaterproofSetting, string> = {
     [WaterproofSetting.UpdateIgnores]: "updateIgnores",
     [WaterproofSetting.ContinuousChecking]: "ContinuousChecking",
     [WaterproofSetting.LogDebugStatements]: "LogDebugStatements",
+    [WaterproofSetting.SendExecInfo]: "sendExecInfo",
 };
 
 /**
@@ -98,6 +100,7 @@ type WaterproofSettingTypes = {
     [WaterproofSetting.UpdateIgnores]: boolean;
     [WaterproofSetting.ContinuousChecking]: boolean;
     [WaterproofSetting.LogDebugStatements]: boolean;
+    [WaterproofSetting.SendExecInfo]: boolean;
 };
 
 /**

--- a/src/lsp-client/rocq/client.ts
+++ b/src/lsp-client/rocq/client.ts
@@ -3,7 +3,7 @@ import { VersionedTextDocumentIdentifier } from "vscode-languageclient";
 
 import { RocqGoalAnswer, RocqGoalRequest, RocqServerStatusToServerStatus, GoalRequest, PpString } from "../../../lib/types";
 import { MessageType } from "../../../shared";
-import { coqFileProgressNotificationType, coqGoalRequestType, coqServerStatusNotificationType } from "./requestTypes";
+import { coqFileProgressNotificationType, coqGoalRequestType, coqServerStatusNotificationType, executionInformationNotificationType } from "./requestTypes";
 import { WaterproofLogger as wpl } from "../../helpers";
 import { LspClient } from "../client";
 import { InputAreaStatus } from "@impermeable/waterproof-editor";
@@ -23,6 +23,22 @@ export class RocqLspClient extends LspClient<RocqGoalRequest, RocqGoalAnswer<PpS
         // call each file progress component when the server has processed a part
         this.disposables.push(this.client.onNotification(coqFileProgressNotificationType, params => {
             this.onFileProgress(params);
+        }));
+
+        this.disposables.push(this.client.onNotification(executionInformationNotificationType, info => {
+            const document = this.activeDocument;
+            const webviewManager = this.webviewManager;
+
+            if (document === undefined || webviewManager === undefined) return;
+
+            const { start, end } = info.range;
+            const from = document.offsetAt(new Position(start.line, start.character));
+            const to = document.offsetAt(new Position(end.line, end.character));
+
+            webviewManager.postMessage(document.uri.toString(), {
+                type: MessageType.executionInfo,
+                body: { from, to }
+            });
         }));
 
         this.disposables.push(this.client.onNotification(coqServerStatusNotificationType, params => {

--- a/src/lsp-client/rocq/requestTypes.ts
+++ b/src/lsp-client/rocq/requestTypes.ts
@@ -13,6 +13,15 @@ export const coqGoalRequestType = new RequestType<RocqGoalRequest, RocqGoalAnswe
 export const coqFileProgressNotificationType = new NotificationType<FileProgressParams>("$/coq/fileProgress");
 
 /**
+ * LSP notification regarding the execution information of the sentence currently being checked.
+ */
+export type ExecutionInformationParams = {
+    textDocument: { uri: string; version: number };
+    range: { start: { line: number; character: number }; end: { line: number; character: number } };
+};
+export const executionInformationNotificationType = new NotificationType<ExecutionInformationParams>("$/coq/executionInformation");
+
+/**
  * Notification type for the coq-lsp specific `serverStatus` notification. Returns a `CoqServerStatus` object that
  * can be either Busy or Idle.
  */

--- a/src/lsp-client/rocq/types.ts
+++ b/src/lsp-client/rocq/types.ts
@@ -16,6 +16,7 @@ export interface CoqLspServerConfig {
     pp_type: 0 | 1 | 2;
     send_diags_extra_data: boolean;
     check_only_on_request: boolean;
+    send_execinfo: boolean;
 }
 
 // TODO: Rewrite namespace to modern syntax
@@ -36,7 +37,8 @@ export namespace CoqLspServerConfig {
             max_errors: WaterproofConfigHelper.get(WaterproofSetting.MaxErrors),
             pp_type: WaterproofConfigHelper.get(WaterproofSetting.PpType),
             send_diags_extra_data: WaterproofConfigHelper.get(WaterproofSetting.SendDiagsExtraData),
-            check_only_on_request: !WaterproofConfigHelper.get(WaterproofSetting.ContinuousChecking)
+            check_only_on_request: !WaterproofConfigHelper.get(WaterproofSetting.ContinuousChecking),
+            send_execinfo: WaterproofConfigHelper.get(WaterproofSetting.SendExecInfo),
         };
     }
 }


### PR DESCRIPTION
### Add busy indicator support to the VS Code extension

 **Depends on the `mapping` branch of the editor repo being merged simultaneously.**

Wires up the LSP `$/coq/executionInformation` notification so the editor can display a busy indicator on the line currently being checked by coq-lsp, and adds a setting to opt out.

**What changed**
- `requestTypes.ts` defines `ExecutionInformationParams` and the notification type for `$/coq/executionInformation`
- `client.ts` subscribes to the notification, converts the LSP range to document offsets, and forwards a `MessageType.executionInfo` message to the webview
- `types.ts` adds `send_execinfo` to `CoqLspServerConfig`, populated from the new setting
- `config-helper.ts` adds `WaterproofSetting.SendExecInfo` mapped to `"sendExecInfo"`
- `Messages.ts` adds the `executionInfo` message type with a `{ from, to }` body, and moves `flash` into alphabetical order
- `index.ts` handles `executionInfo` by calling `setBusyIndicator(range.from)`, and clears indicators when a `progress` message arrives with an empty progress array
- `package.json` registers `waterproof.sendExecInfo` (boolean, default `true`)
- `messages.md` documents the new message
