### PR TITLE
Fix proof bar turning green prematurely in Lean (closes #313, #316)

### DIFF
--- a/__tests__/lsp-client/lean/client.determineProofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.determineProofStatus.test.ts
@@ -183,4 +183,16 @@ describe("LeanLspClient.determineProofStatus", () => {
         expect(await call(instance)).toBe(InputAreaStatus.Correct);
     });
 
+    it("returns Incorrect when requestGoals resolves with null", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue(null);
+        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("returns Incorrect when requestGoals resolves with undefined", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue(undefined);
+        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+    });
+
 });

--- a/__tests__/lsp-client/lean/client.determineProofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.determineProofStatus.test.ts
@@ -1,0 +1,186 @@
+jest.mock("vscode", () => {
+    const Position = class {
+        constructor(public line: number, public character: number) {}
+        translate(lineDelta: number, charDelta: number) {
+            return new Position(this.line + lineDelta, this.character + charDelta);
+        }
+    };
+
+    const Range = class {
+        constructor(
+            public start: InstanceType<typeof Position>,
+            public end:   InstanceType<typeof Position>
+        ) {}
+        intersection(other: InstanceType<typeof Range>): InstanceType<typeof Range> | undefined {
+            const startLine = Math.max(this.start.line, other.start.line);
+            const endLine   = Math.min(this.end.line,   other.end.line);
+            if (startLine > endLine) return undefined;
+            return new Range(new Position(startLine, 0), new Position(endLine, 0));
+        }
+        get isEmpty() {
+            return this.start.line === this.end.line
+                && this.start.character === this.end.character;
+        }
+    };
+
+    return {
+        Position,
+        Range,
+        DiagnosticSeverity: { Error: 0, Warning: 1, Information: 2, Hint: 3 },
+        EventEmitter: class {
+            fire()  {}
+            event = () => ({ dispose: () => {} });
+        },
+        workspace: {
+            getConfiguration:         jest.fn(() => ({ get: jest.fn((_key: string, def?: any) => def) })),
+            onDidChangeConfiguration: jest.fn(() => ({ dispose: jest.fn() })),
+            onDidChangeTextDocument:  jest.fn(() => ({ dispose: jest.fn() })),
+        },
+        languages: {
+            createDiagnosticCollection: jest.fn(() => ({ set: jest.fn(), dispose: jest.fn() })),
+            getDiagnostics:             jest.fn(() => []),
+            onDidChangeDiagnostics:     jest.fn(() => ({ dispose: jest.fn() })),
+        },
+        window: {
+            createOutputChannel: jest.fn(() => ({
+                appendLine: jest.fn(),
+                dispose:    jest.fn(),
+            })),
+        },
+    };
+}, { virtual: true });
+
+jest.mock("vscode-languageclient", () => ({
+    LogTraceNotification:  { type: "$/logTrace" },
+    RequestType:           jest.fn().mockImplementation(() => ({})),
+    NotificationType:      jest.fn().mockImplementation(() => ({})),
+    DocumentSymbolRequest: { type: {} },
+}), { virtual: true });
+
+jest.mock("vscode-languageserver-types", () => ({
+    VersionedTextDocumentIdentifier: { create: jest.fn((uri, v) => ({ uri, version: v })) },
+}), { virtual: true });
+
+jest.mock("../../../shared",        () => ({ MessageType: {}, FileProgressKind: { Processing: 1 } }), { virtual: true });
+jest.mock("../../../lib/types",     () => ({}), { virtual: true });
+jest.mock("../../helpers",          () => ({
+    WaterproofConfigHelper: { get: jest.fn(() => false) },
+    WaterproofLogger:       { log: jest.fn(), debug: jest.fn() },
+    WaterproofSetting:      {},
+    qualifiedSettingName:   jest.fn(s => s),
+}), { virtual: true });
+jest.mock("../sentenceManager",     () => ({ SentenceManager: class { onProgress() {} dispose() {} } }), { virtual: true });
+jest.mock("../clientTypes",         () => ({}), { virtual: true });
+jest.mock("../requestTypes",        () => ({ convertToSimple: jest.fn() }), { virtual: true });
+jest.mock("../qedStatus",           () => ({ findOccurrences: jest.fn(() => []) }), { virtual: true });
+jest.mock("./requestTypes",         () => ({
+    leanFileProgressNotificationType: "$/lean/fileProgress",
+    leanGoalRequestType:              "$/lean/plainGoal",
+}), { virtual: true });
+jest.mock("@impermeable/waterproof-editor", () => ({
+    InputAreaStatus: { Correct: "Correct", Incorrect: "Incorrect", Invalid: "Invalid" },
+}), { virtual: true });
+jest.mock("@leanprover/infoview-api", () => ({}), { virtual: true });
+
+import { Range, Position, DiagnosticSeverity } from "vscode";
+import { InputAreaStatus } from "@impermeable/waterproof-editor";
+import { LeanLspClient } from "../../../src/lsp-client/lean/client";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const INPUT_AREA = new Range(new Position(0, 0), new Position(5, 0));
+
+const FAKE_DOCUMENT = {
+    uri:        { toString: () => "file:///test.lean", path: "/test.lean" },
+    version:    1,
+    getText:    () => ":::input\n\n:::\n",
+    offsetAt:   (pos: any) => pos.line * 100 + pos.character,
+    positionAt: (offset: number) => new Position(Math.floor(offset / 100), offset % 100),
+    lineCount:  10,
+} as any;
+
+function makeClientDouble() {
+    return {
+        isRunning:              jest.fn(() => true),
+        start:                  jest.fn(() => Promise.resolve()),
+        dispose:                jest.fn(() => Promise.resolve()),
+        onNotification:         jest.fn(() => ({ dispose: jest.fn() })),
+        sendRequest:            jest.fn(),
+        middleware:             { handleDiagnostics: undefined as any },
+        protocol2CodeConverter: { asRange: (r: any) => r },
+        code2ProtocolConverter: { asUri: (u: any) => u.toString(), asDiagnostic: (d: any) => d },
+    };
+}
+
+function makeClient(isBusy = false) {
+    const clientDouble = makeClientDouble();
+    const instance = new LeanLspClient(
+        jest.fn(() => clientDouble) as any,
+        { appendLine: jest.fn() } as any,
+    );
+    (instance as any).activeDocument = FAKE_DOCUMENT;
+    (instance as any).isBusy = isBusy;
+    return instance;
+}
+
+const call = (instance: LeanLspClient, diags: any[] = [], area = INPUT_AREA) =>
+    (instance as any).determineProofStatus(FAKE_DOCUMENT, area, diags);
+
+const diag = (startLine: number, endLine: number, severity: number) => ({
+    message:  "test",
+    severity,
+    range: new Range(new Position(startLine, 0), new Position(endLine, 0)),
+});
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+describe("LeanLspClient.determineProofStatus", () => {
+
+    it("returns Incorrect when isBusy", async () => {
+        const instance = makeClient(true);
+        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("returns Incorrect for an Error diagnostic inside the area", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        expect(await call(instance, [diag(1, 3, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("returns Incorrect for an Error diagnostic on the area boundary", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        expect(await call(instance, [diag(4, 5, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("ignores an Error diagnostic outside the area", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        expect(await call(instance, [diag(10, 11, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Correct);
+    });
+
+    it("does not treat Warning/Info/Hint diagnostics as blocking", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        expect(await call(instance, [
+            diag(1, 2, DiagnosticSeverity.Warning),
+            diag(2, 3, DiagnosticSeverity.Information),
+            diag(3, 4, DiagnosticSeverity.Hint),
+        ])).toBe(InputAreaStatus.Correct);
+    });
+
+    it("returns Incorrect when goals are non-empty", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [{ type: "⊢ False" }] });
+        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("returns Correct when idle, no errors, and goals are empty", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        expect(await call(instance)).toBe(InputAreaStatus.Correct);
+    });
+
+});

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -31,13 +31,6 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
     private _client?: LanguageClient;
 
     /**
-     * Gets or sets whether the lsp is busy. Currently only used be the lean client. 
-     * NOTE: This is never set to false by the rocq client.
-     * However, it currently never uses this property anyway.
-     */
-    protected isBusy: boolean = true; 
-
-    /**
      * Gets the underlying VS Code language client.
      * Initializes one if necessary.
      */
@@ -285,7 +278,7 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                 webviewManager.has(event.document.uri.toString())
                 && event.document.languageId === this.language
             ) {
-                this.isBusy = true;
+                this.onDocumentChanged();
 
                 this.updateCompletions(event.document);
             }
@@ -307,6 +300,12 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
     abstract requestGoals(position: Position): Promise<GoalAnswerT>;
     /** Sends an LSP request to retrieve the goals at the active cursor position. */
     abstract requestGoals(): Promise<GoalAnswerT>;
+
+    /**
+     * Called when the active document changes. Subclasses can use this to
+     * update any state that depends on the document being up to date.
+     */
+    protected abstract onDocumentChanged(): void;
 
     async requestSymbols(document?: TextDocument): Promise<DocumentSymbol[]> {
         // use active document if no document is given

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -295,11 +295,11 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
     abstract createGoalsRequestParameters(document: TextDocument, position: Position): GoalRequestT;
 
     /** Sends an LSP request with the specified parameters to retrieve the goals. */
-    abstract requestGoals(parameters: GoalRequestT): Promise<GoalAnswerT>;
+    abstract requestGoals(parameters: GoalRequestT): Promise<GoalAnswerT | null>;
     /** Sends an LSP request to retrieve the goals at `position` in the active document. */
-    abstract requestGoals(position: Position): Promise<GoalAnswerT>;
+    abstract requestGoals(position: Position): Promise<GoalAnswerT | null>;
     /** Sends an LSP request to retrieve the goals at the active cursor position. */
-    abstract requestGoals(): Promise<GoalAnswerT>;
+    abstract requestGoals(): Promise<GoalAnswerT | null>;
 
     /**
      * Called when the active document changes. Subclasses can use this to

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -31,6 +31,13 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
     private _client?: LanguageClient;
 
     /**
+     * Gets or sets whether the lsp is busy. Currently only used be the lean client. 
+     * NOTE: This is never set to false by the rocq client.
+     * However, it currently never uses this property anyway.
+     */
+    protected isBusy: boolean = true; 
+
+    /**
      * Gets the underlying VS Code language client.
      * Initializes one if necessary.
      */
@@ -278,6 +285,8 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                 webviewManager.has(event.document.uri.toString())
                 && event.document.languageId === this.language
             ) {
+                this.isBusy = true;
+
                 this.updateCompletions(event.document);
             }
         }));

--- a/src/lsp-client/composite.ts
+++ b/src/lsp-client/composite.ts
@@ -81,7 +81,7 @@ export class CompositeClient implements ILspClient {
         if (client instanceof LeanLspClient) {
             const goalResponse = await client.requestGoals(params);
 
-            if (goalResponse.goals === undefined) {
+            if (goalResponse?.goals === undefined) {
                 throw new Error("Response contained no goals.");
             }
 

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -16,6 +16,12 @@ import { FileProgressKind, MessageType } from "../../../shared";
 export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     language = "lean4";
 
+    /**
+    * Whether the Lean server is still processing the document.
+    * Used to avoid marking a proof as complete before checking has finished.
+    */
+    private isBusy: boolean = true; 
+
     constructor(clientProvider: LanguageClientProvider, channel: OutputChannel) {
         super(clientProvider, channel);
 
@@ -227,5 +233,9 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     async dispose(timeout?: number): Promise<void> {
         await super.dispose(timeout);
         this.clientStoppedEmitter.fire({message: 'Lean server has stopped', reason: ''});
+    }
+
+    protected onDocumentChanged(): void {
+        this.isBusy = true;
     }
 }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -199,12 +199,13 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         const goalsParams = this.createGoalsRequestParameters(document, goalsPosition);
         const response = await this.requestGoals(goalsParams);
 
-        // It might seem like you can remove this check, since it won't give a type error
-        // when you do so, but doing so would break everything.
+        /** It might seem like you can remove this check, since it won't give a type error
+        * when you do so, but doing so would break everything.
+        * this happens because {@link leanGoalRequestType} is typed wrong. 
+        */
         if (!response) {
             return InputAreaStatus.Incorrect;
         }
-
         
         const status = response.goals.length > 0 ? InputAreaStatus.Incorrect : InputAreaStatus.Correct;
         return status;

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -73,23 +73,13 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         });
     }
 
-    /**
-     * Stores the most recent file-progress notification for the active document.
-     * Ranges inside are VSCode Ranges (converted by super.onFileProgress).
-     */
-    private lastFileProgress: FileProgressParams | null = null;
-
     protected async onFileProgress(progress: FileProgressParams) {
 
         // Call super first so LSP ranges are converted to VSCode Ranges before we store/use them.
         super.onFileProgress(progress);
-;
+
         if (this.activeDocument?.uri.toString() === progress.textDocument.uri) {
-            // Store so determineProofStatus can check whether Lean has finished the input area.
-            this.lastFileProgress = progress;
-
-            this.computeInputAreaStatus(this.activeDocument);
-
+            
             // --- busy-indicator (Lean edition) ---
             // Find the first processing range, where we want to add the busy-indicator to.
             const firstProcessing = progress.processing.find(
@@ -109,6 +99,8 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
                     body: { from, to },
                 });
             }
+            this.isBusy = processingRanges.length > 0;
+            this.computeInputAreaStatus(this.activeDocument);
         }
     }
 
@@ -172,36 +164,12 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     }
 
     protected async determineProofStatus(document: TextDocument, inputArea: Range, diags: Array<Diagnostic>): Promise<InputAreaStatus> {
-        const content = document.getText();
-
-        const inputAreaStartOffset = document.offsetAt(inputArea.start);
-        const inputAreaEndOffset   = document.offsetAt(inputArea.end);
-
-        const nextQed   = content.indexOf("\nQed\n",   inputAreaStartOffset);
-        const nextProof = content.indexOf("\nProof:\n", inputAreaStartOffset);
-
-        if (nextProof && nextQed >= nextProof) {
-            return InputAreaStatus.Invalid;
-        }
 
         // If Lean hasn't finished processing up to the end of this input area, an empty goals
         // response simply means "not checked yet" rather than "proof complete".  Guard against
         // that to prevent the bar from turning green prematurely (e.g. while typing "We ap" or
         // when the proof has invalid syntax like "Help\n• Fix a : ℝ\n" without a closing Qed).
-        //
-        // lastFileProgress is null => no progress received yet, cannot trust goals.
-        // processing array non-empty and a range starts at-or-before the input area end
-        //   => Lean hasn't verified this far, cannot trust goals.
-        if (this.lastFileProgress === null) {
-            return InputAreaStatus.Incorrect;
-        }
-
-        const isStillProcessing = this.lastFileProgress.processing.some(p =>
-            (p.kind === undefined || p.kind === FileProgressKind.Processing) &&
-            document.offsetAt(p.range.start) <= inputAreaEndOffset
-        );
-
-        if (isStillProcessing) {
+        if (this.isBusy) {
             return InputAreaStatus.Incorrect;
         }
 

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -105,6 +105,8 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
                     type: MessageType.executionInfo,
                     body: { from, to },
                 });
+            } else {
+                this.isBusy = false;
             }
             this.computeInputAreaStatus(this.activeDocument);
         }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -199,7 +199,13 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         const goalsParams = this.createGoalsRequestParameters(document, goalsPosition);
         const response = await this.requestGoals(goalsParams);
 
+        // It might seem like you can remove this check, since it won't give a type error
+        // when you do so, but doing so would break everything.
+        if (!response) {
+            return InputAreaStatus.Incorrect;
+        }
 
+        
         const status = response.goals.length > 0 ? InputAreaStatus.Incorrect : InputAreaStatus.Correct;
         return status;
     }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -125,7 +125,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         };
     }
 
-    async requestGoals(params?: LeanGoalRequest | Position): Promise<LeanGoalAnswer> {
+    async requestGoals(params?: LeanGoalRequest | Position): Promise<LeanGoalAnswer | null> {
         if (!params || "line" in params) {  // if `params` is not a `GoalRequest` ...
             params ??= this.activeCursorPosition;
             if (!this.activeDocument || !params) {
@@ -199,10 +199,6 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         const goalsParams = this.createGoalsRequestParameters(document, goalsPosition);
         const response = await this.requestGoals(goalsParams);
 
-        /** It might seem like you can remove this check, since it won't give a type error
-        * when you do so, but doing so would break everything.
-        * this happens because {@link leanGoalRequestType} is typed wrong. 
-        */
         if (!response) {
             return InputAreaStatus.Incorrect;
         }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -92,6 +92,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
                 p => p.kind === undefined || p.kind === FileProgressKind.Processing
             );
             if (firstProcessing && this.webviewManager) {
+                this.isBusy = true;
                 const { line, character } = firstProcessing.range.start;
                 const from = this.activeDocument.offsetAt(new Position(line, character));
                 const to   = this.activeDocument.offsetAt(new Position(
@@ -105,7 +106,6 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
                     body: { from, to },
                 });
             }
-            this.isBusy = processingRanges.length > 0;
             this.computeInputAreaStatus(this.activeDocument);
         }
     }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -1,6 +1,6 @@
 import { LeanGoalAnswer, LeanGoalRequest } from "../../../lib/types";
 import { LspClient } from "../client";
-import { EventEmitter, Position, TextDocument, Disposable, Range, OutputChannel, Diagnostic } from "vscode";
+import { EventEmitter, Position, TextDocument, Disposable, Range, OutputChannel, Diagnostic, DiagnosticSeverity } from "vscode";
 import { VersionedTextDocumentIdentifier } from "vscode-languageserver-types";
 import { FileProgressParams } from "../requestTypes";
 import { leanFileProgressNotificationType, leanGoalRequestType, LeanPublishDiagnosticsParams } from "./requestTypes";
@@ -73,8 +73,21 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         });
     }
 
+    /**
+     * Stores the most recent file-progress notification for the active document.
+     * Ranges inside are VSCode Ranges (converted by super.onFileProgress).
+     */
+    private lastFileProgress: FileProgressParams | null = null;
+
     protected async onFileProgress(progress: FileProgressParams) {
+
+        // Call super first so LSP ranges are converted to VSCode Ranges before we store/use them.
+        super.onFileProgress(progress);
+;
         if (this.activeDocument?.uri.toString() === progress.textDocument.uri) {
+            // Store so determineProofStatus can check whether Lean has finished the input area.
+            this.lastFileProgress = progress;
+
             this.computeInputAreaStatus(this.activeDocument);
 
             // --- busy-indicator (Lean edition) ---
@@ -97,8 +110,6 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
                 });
             }
         }
-
-        super.onFileProgress(progress);
     }
 
     createGoalsRequestParameters(document: TextDocument, position: Position): LeanGoalRequest {
@@ -163,31 +174,58 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     protected async determineProofStatus(document: TextDocument, inputArea: Range, diags: Array<Diagnostic>): Promise<InputAreaStatus> {
         const content = document.getText();
 
-        const nextQed = content.indexOf("\nQed\n", document.offsetAt(inputArea.start));
-        const nextProof = content.indexOf("\nProof:\n", document.offsetAt(inputArea.start));
+        const inputAreaStartOffset = document.offsetAt(inputArea.start);
+        const inputAreaEndOffset   = document.offsetAt(inputArea.end);
+
+        const nextQed   = content.indexOf("\nQed\n",   inputAreaStartOffset);
+        const nextProof = content.indexOf("\nProof:\n", inputAreaStartOffset);
 
         if (nextProof && nextQed >= nextProof) {
             return InputAreaStatus.Invalid;
         }
 
-        // We do an explicit check for the case where we have
-        // Fix b :
-        // QED
-        // As these cases are not covered by the empty goals statemement below.
-        const hasUnexpectedTokenError = diags.some(v => {
+        // If Lean hasn't finished processing up to the end of this input area, an empty goals
+        // response simply means "not checked yet" rather than "proof complete".  Guard against
+        // that to prevent the bar from turning green prematurely (e.g. while typing "We ap" or
+        // when the proof has invalid syntax like "Help\n• Fix a : ℝ\n" without a closing Qed).
+        //
+        // lastFileProgress is null => no progress received yet, cannot trust goals.
+        // processing array non-empty and a range starts at-or-before the input area end
+        //   => Lean hasn't verified this far, cannot trust goals.
+        if (this.lastFileProgress === null) {
+            return InputAreaStatus.Incorrect;
+        }
+
+        const isStillProcessing = this.lastFileProgress.processing.some(p =>
+            (p.kind === undefined || p.kind === FileProgressKind.Processing) &&
+            document.offsetAt(p.range.start) <= inputAreaEndOffset
+        );
+
+        if (isStillProcessing) {
+            return InputAreaStatus.Incorrect;
+        }
+
+        const diagsInArea = diags.filter(v => {
             const intersection = inputArea.intersection(v.range);
-            return intersection !== undefined &&
-                !intersection.isEmpty &&
-                // This is the error that is emitted when doing something like Fix b : ... with QED on the next line.
-                v.message === "unexpected token 'QED'; expected term";
+            return intersection !== undefined && !intersection.isEmpty;
         });
-        // If we have an unexpected token error we mark the input area as incorrect.
-        if (hasUnexpectedTokenError) return InputAreaStatus.Incorrect;
 
-        // request goals and return conclusion based on them
-        const response = await this.requestGoals(this.createGoalsRequestParameters(document, inputArea.end.translate(0, 0)));
+        // If there are any error-level diagnostics inside the input area, the proof is wrong.
+        // This catches cases like an incomplete tactic keyword (e.g. just "We") which can make
+        // Lean report empty goals at the query position while still being invalid.
+        const hasErrorDiagnostic = diagsInArea.some(d => d.severity === DiagnosticSeverity.Error);
+        if (hasErrorDiagnostic) {
+            return InputAreaStatus.Incorrect;
+        }
+ 
+        const goalsPosition = inputArea.end.translate(0, 0);
+        
+        const goalsParams = this.createGoalsRequestParameters(document, goalsPosition);
+        const response = await this.requestGoals(goalsParams);
 
-        return response?.goals.length ? InputAreaStatus.Incorrect : InputAreaStatus.Correct;
+
+        const status = response.goals.length > 0 ? InputAreaStatus.Incorrect : InputAreaStatus.Correct;
+        return status;
     }
 
     // Emitters for infoview

--- a/src/lsp-client/lean/requestTypes.ts
+++ b/src/lsp-client/lean/requestTypes.ts
@@ -5,7 +5,7 @@ import { FileProgressParams } from "../requestTypes";
 /**
  * LSP request to obtain the goals at a specific point in the doc.
  */
-export const leanGoalRequestType = new RequestType<LeanGoalRequest, LeanGoalAnswer, void>("$/lean/plainGoal");
+export const leanGoalRequestType = new RequestType<LeanGoalRequest, LeanGoalAnswer | null, void>("$/lean/plainGoal");
 
 /**
  * LSP notification regarding the progress on processing the document server side

--- a/src/lsp-client/rocq/client.ts
+++ b/src/lsp-client/rocq/client.ts
@@ -195,4 +195,8 @@ export class RocqLspClient extends LspClient<RocqGoalRequest, RocqGoalAnswer<PpS
         if (!this.activeCursorPosition) return undefined;
         return this.sentenceManager.getEndOfSentence(this.activeCursorPosition);
     }
+
+    protected onDocumentChanged(): void {
+        // Rocq tracks its own busy state via the coqServerStatus notification.
+    }
 }


### PR DESCRIPTION
### Description

The proof status bar for Lean input areas was turning green at inappropriate times, most notably while the user was still typing (e.g. after typing `"We "`), or when a proof contained invalid syntax (like "Help\n• Fix a : ℝ\n") that happened to produce empty goals. This PR rewrites `determineProofStatus` in the Lean client to correctly reflect proof state by (1) guarding against Lean still processing, (2) checking for error-level diagnostics, and (3) only then querying goals.

The race condition that I mentioned in the issue description has been resolved.

As a bonus, it also fixes #316, where the last input area of a Lean document was incorrectly marked yellow instead of green. This was caused by the following lines in `determineProofStatus`:

```typescript
        const content = document.getText();

        const nextQed = content.indexOf("\nQed\n", document.offsetAt(inputArea.start));
        const nextProof = content.indexOf("\nProof:\n", document.offsetAt(inputArea.start));

        if (nextProof && nextQed >= nextProof) {
            return InputAreaStatus.Invalid;
        }
```

This bug was messing with my unit-tests, that is why I deleted it in this PR. The fact that `\nQed\n` is not properly capitalised, indicates to me that this is dead code that can safely be removed.

### Changes

**`src/lsp-client/client.ts` - `onDocumentChanged` abstract hook**

An abstract `onDocumentChanged(): void` method is added to `LspClient`. It is called whenever a text-document change is detected. This replaces the previous approach of setting a `protected isBusy` flag directly in the base class, giving each subclass full control over how it responds to document changes.

**`src/lsp-client/lean/client.ts` - `isBusy` flag and rewritten `determineProofStatus`**

A `private isBusy: boolean` field (initially `true`) is added to `LeanLspClient`. It is set back to `true` in `onDocumentChanged`, and set to `false` once Lean reports no remaining processing ranges in `onFileProgress`.

The new logic in `determineProofStatus` is:

1. **If `isBusy` is `true`**, return `Incorrect` immediately. Lean hasn't finished processing the input area yet, so an empty goals response would mean "not checked yet" rather than "proof complete".
2. **If there are any `Error`-severity diagnostics whose range intersects the input area**, return `Incorrect`. This catches cases where an incomplete tactic keyword (e.g. just `"We"`) causes Lean to report empty goals at the query position despite the proof being invalid.
3. **Otherwise**, request goals at the end of the input area. Return `Correct` if goals are empty, `Incorrect` if not.

**`src/lsp-client/lean/client.ts` - `onFileProgress` ordering**

`super.onFileProgress(progress)` is now called *before* processing the progress ranges, so that LSP ranges are converted to VS Code `Range` objects before the Lean client reads them.

**`src/lsp-client/rocq/client.ts` - `onDocumentChanged` no-op**

The Rocq client implements `onDocumentChanged` as a no-op, since it tracks its own busy state via the `coqServerStatus` notification.

**`__tests__/lsp-client/lean/client.determineProofStatus.test.ts` - new test file**

Seven unit tests cover the key branches of `determineProofStatus`.

### Testing this PR

**Automated tests:** Run `jest __tests__/lsp-client/lean/client.determineProofStatus.test.ts`. All seven tests should pass.

**Manual testing (for #313 - premature green bar):**
1. Open a Lean exercise sheet.
2. Inside an input area, type a partial tactic such as `We`, `We ap` or `We apply` and pause briefly.
3. The bar should remain red, it must **not** flash green while Lean is still processing or while the tactic is incomplete.
4. When typing invalid lean syntax (e.g. `Help\n• Fix a : ℝ\n`), the bar shouldn't turn green like it used to.
5. Valid proofs should still make the bar green.

**Manual testing (for #316 - last bar stuck yellow):**
1. Open a Lean file with multiple input areas (e.g. `sheet1_conjunction.lean`).
2. Complete all proofs correctly and wait for Lean to finish checking.
3. The **last** input area's bar should turn green, not yellow.

**Known (non-)issues:** Typing `hint` or `sorry` inside an input area still causes the bar to turn green. The `sorry` case may be intentional (though we could make it return `Invalid` or something); the `hint` case was pre-existing and is outside the scope of this PR.


closes #313, #316