### PR TITLE
Sorry is invalid, hint is incorrect, isBusy flag properly resets.

### DIFF
--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -76,16 +76,7 @@ jest.mock("../../../src/helpers",   () => ({
 jest.mock("../sentenceManager",     () => ({ SentenceManager: class { onProgress() {} dispose() {} } }), { virtual: true });
 jest.mock("../clientTypes",         () => ({}), { virtual: true });
 jest.mock("../requestTypes",        () => ({ convertToSimple: jest.fn() }), { virtual: true });
-jest.mock("../qedStatus",           () => ({
-    findOccurrences: jest.fn((substr: string, str: string) => {
-        const indices: number[] = [];
-        const substrLen = substr.length;
-        for (let i = 0; (i = str.indexOf(substr, i)) >= 0; i += substrLen) {
-            indices.push(i);
-        }
-        return indices;
-    }),
-}), { virtual: true });
+
 jest.mock("./requestTypes",         () => ({
     leanFileProgressNotificationType: "$/lean/fileProgress",
     leanGoalRequestType:              "$/lean/plainGoal",
@@ -159,12 +150,46 @@ const messageDiag = (message: string, startLine: number, startCharacter = 0) => 
     ),
 });
 
-const makeDocument = (content: string) => ({
-    ...FAKE_DOCUMENT,
-    getText:    () => content,
-    positionAt: (offset: number) => new Position(0, offset),
-    offsetAt:   (pos: any) => pos.character,
-}) as any;
+function makeDocument(content: string) {
+    const lines = content.split("\n");
+ 
+    const positionAt = (offset: number): { line: number; character: number } => {
+        let remaining = offset;
+        for (let i = 0; i < lines.length; i++) {
+            // +1 for the newline that split() consumed
+            const lineLen = lines[i].length + 1;
+            if (remaining < lineLen) return new Position(i, remaining);
+            remaining -= lineLen;
+        }
+        // offset == content.length → end of last line
+        return new Position(lines.length - 1, lines[lines.length - 1].length);
+    };
+ 
+    const offsetAt = (pos: { line: number; character: number }): number => {
+        let offset = 0;
+        for (let i = 0; i < pos.line; i++) offset += lines[i].length + 1;
+        return offset + pos.character;
+    };
+ 
+    return {
+        ...FAKE_DOCUMENT,
+        getText:    () => content,
+        lineCount:  lines.length,
+        positionAt,
+        offsetAt,
+    } as any;
+}
+
+function posOf(content: string, needle: string, fromOffset = 0) {
+    const idx = content.indexOf(needle, fromOffset);
+    if (idx === -1) throw new Error(`"${needle}" not found after offset ${fromOffset}`);
+    const before = content.slice(0, idx);
+    const line = before.split("\n").length - 1;
+    const character = idx - before.lastIndexOf("\n") - 1;
+    return { line, character, offset: idx };
+}
+ 
+ 
 
 // ===========================================================================
 // Tests
@@ -291,8 +316,61 @@ describe("LeanLspClient.earlyProofStatus", () => {
     });
 });
 
-describe("LeanLspClient.getInputAreas ordering", () => {
-    it("returns input areas in source order", () => {
+describe("LeanLspClient.getInputAreas", () => {
+ 
+    it("returns an empty array when there are no input areas", () => {
+        const instance = makeClient();
+        const content = "no input areas here\n";
+        const document = makeDocument(content);
+ 
+        const areas = (instance as any).getInputAreas(document) as Range[];
+ 
+        expect(areas).toHaveLength(0);
+    });
+ 
+    it("returns a single range whose start is the :::input tag and end is the ::: closing tag", () => {
+        const instance = makeClient();
+        const content = [
+            "before",
+            ":::input",
+            "proof goes here",
+            ":::",
+            "after",
+        ].join("\n");
+        const document = makeDocument(content);
+ 
+        const areas = (instance as any).getInputAreas(document) as Range[];
+ 
+        expect(areas).toHaveLength(1);
+ 
+        const openPos  = posOf(content, ":::input\n");
+        const closePos = posOf(content, ":::\n");
+ 
+        expect(areas[0].start).toEqual(new Position(openPos.line,  openPos.character));
+        expect(areas[0].end  ).toEqual(new Position(closePos.line, closePos.character));
+    });
+ 
+    it("correctly locates the closing ::: even when the body contains text", () => {
+        const instance = makeClient();
+        const content = [
+            ":::input",
+            "  By h we get x",
+            "  We conclude",
+            ":::",
+            "",
+        ].join("\n");
+        const document = makeDocument(content);
+ 
+        const areas = (instance as any).getInputAreas(document) as Range[];
+ 
+        expect(areas).toHaveLength(1);
+ 
+        // Start must be line 0 (the :::input line), end must be line 3 (the ::: line)
+        expect(areas[0].start.line).toBe(0);
+        expect(areas[0].end.line  ).toBe(3);
+    });
+
+    it("returns two areas in document order for a file with two input blocks", () => {
         const instance = makeClient();
         const content = [
             "before",
@@ -306,20 +384,26 @@ describe("LeanLspClient.getInputAreas ordering", () => {
             "",
         ].join("\n");
         const document = makeDocument(content);
-
-        // @ts-expect-error protected
-        const areas = instance.getInputAreas(document) as Range[];
+ 
+        const areas = (instance as any).getInputAreas(document) as Range[];
+ 
         expect(areas).toHaveLength(2);
-
-        const starts = areas.map(area => document.offsetAt(area.start));
-        const firstOpen = content.indexOf(":::input\n");
-        const secondOpen = content.indexOf(":::input\n", firstOpen + 1);
-
-        expect(starts).toEqual([firstOpen, secondOpen]);
-        expect(starts).toEqual([...starts].sort((a, b) => a - b));
+ 
+        const firstOpen  = posOf(content, ":::input\n");
+        const firstClose = posOf(content, ":::\n");
+        const secondOpen = posOf(content, ":::input\n", firstOpen.offset + 1);
+        const secondClose = posOf(content, ":::\n", firstClose.offset + 1);
+ 
+        // First area
+        expect(areas[0].start).toEqual(new Position(firstOpen.line,   firstOpen.character));
+        expect(areas[0].end  ).toEqual(new Position(firstClose.line,  firstClose.character));
+ 
+        // Second area
+        expect(areas[1].start).toEqual(new Position(secondOpen.line,  secondOpen.character));
+        expect(areas[1].end  ).toEqual(new Position(secondClose.line, secondClose.character));
     });
-
-    it("keeps consecutive areas monotonic for lower-bound logic", () => {
+ 
+    it("each area starts after the previous area ends (areas do not overlap)", () => {
         const instance = makeClient();
         const content = [
             ":::input",
@@ -334,21 +418,19 @@ describe("LeanLspClient.getInputAreas ordering", () => {
             "",
         ].join("\n");
         const document = makeDocument(content);
-
+        
         // @ts-expect-error protected
         const areas = instance.getInputAreas(document) as Range[];
         expect(areas).toHaveLength(3);
-
-        const starts = areas.map(area => document.offsetAt(area.start));
-        const ends = areas.map(area => document.offsetAt(area.end));
-
+ 
         for (let i = 1; i < areas.length; i++) {
-            expect(starts[i]).toBeGreaterThan(starts[i - 1]);
-            expect(ends[i - 1]).toBeLessThanOrEqual(starts[i]);
+            const prevEndOffset  = document.offsetAt(areas[i - 1].end);
+            const currStartOffset = document.offsetAt(areas[i].start);
+            expect(currStartOffset).toBeGreaterThan(prevEndOffset);
         }
     });
-
-    it("stays sorted on production-like multilean content", () => {
+ 
+    it("finds exactly three areas in realistic multilean content at the correct offsets", () => {
         const instance = makeClient();
         const content = [
             "#doc (WaterproofGenre) \"Index\" =>",
@@ -358,16 +440,13 @@ describe("LeanLspClient.getInputAreas ordering", () => {
             "## ATC - 003",
             "```lean",
             "Example \"ATC - 003\"",
-            "  Given:",
-            "  Assume:",
-            "  Conclusion: ∀ a : ℝ, ∀ b > 5, ∃ c, c > b - a",
             "Proof:",
             "```",
-            ":::input",
+            ":::input",      // line 9  - first open
             "```lean",
             "",
             "```",
-            ":::",
+            ":::",            // line 13 - first close
             "",
             "## ATC - 009",
             ":::hint \"Show hint\"",
@@ -375,51 +454,67 @@ describe("LeanLspClient.getInputAreas ordering", () => {
             ":::",
             "```lean",
             "Example \"ATC - 009\"",
-            "  Given:",
-            "  Assume:",
-            "  Conclusion: ∀ a : ℝ, ∀ b > 5, ∃ c, c > b - a",
             "Proof:",
             "```",
-            ":::input",
+            ":::input",      // line 23 - second open
             "```lean",
             "",
             "```",
-            ":::",
+            ":::",            // line 27 - second close
             "",
             "## ATC - 014",
             "```lean",
             "Example \"ATC - 014\"",
-            "  Given: (f : ℝ → ℝ) (u : ℕ → ℝ) (x₀ : ℝ)",
-            "  Assume: (hu : u converges to x₀) (hf : f is continuous at x₀)",
-            "  Conclusion: (f ∘ u) converges to f x₀",
             "Proof:",
             "```",
-            ":::input",
+            ":::input",      // line 34 - third open
             "```lean",
             "  Fix ε > 0",
-            "  By hf applied to ε using that ε > 0 we get δ such that",
-            "    (δ_pos : δ > 0) and (Hf : ∀ x, |x - x₀| ≤ δ ⇒ |f x - f x₀| ≤ ε)",
             "```",
-            ":::",
+            ":::",            // line 38 - third close
             "",
             "::::",
             "",
         ].join("\n");
         const document = makeDocument(content);
-
+ 
         // @ts-expect-error protected
         const areas = instance.getInputAreas(document) as Range[];
-        expect(areas.length).toBeGreaterThan(2);
-
-        const starts = areas.map(area => document.offsetAt(area.start));
-
-        const expectedOpenOffsets: number[] = [];
-        for (let i = 0; (i = content.indexOf(":::input\n", i)) >= 0; i += ":::input\n".length) {
-            expectedOpenOffsets.push(i);
+ 
+        expect(areas).toHaveLength(3);
+ 
+        // Collect the ground-truth positions by scanning the content string directly
+        // so this test does not depend on line-number constants staying in sync with
+        // the content array above.
+        const openPositions: { line: number; character: number }[] = [];
+        const closePositions: { line: number; character: number }[] = [];
+ 
+        let searchFrom = 0;
+        while (true) {
+            const found = posOf(content, ":::input\n", searchFrom);
+            if (found.offset === -1) break;
+            openPositions.push({ line: found.line, character: found.character });
+            searchFrom = found.offset + ":::input\n".length;
+            if (openPositions.length === 3) break;
         }
-
-        expect(starts).toEqual(expectedOpenOffsets);
-        expect(starts).toEqual([...starts].sort((a, b) => a - b));
+ 
+        searchFrom = 0;
+        // Each closing ::: comes after its matching :::input; collect them in order
+        // by scanning after each open position we already found.
+        for (const open of openPositions) {
+            const openOffset = document.offsetAt(open);
+            const found = posOf(content, ":::\n", openOffset + ":::input\n".length);
+            closePositions.push({ line: found.line, character: found.character });
+        }
+ 
+        for (let i = 0; i < 3; i++) {
+            expect(areas[i].start).toEqual(new Position(openPositions[i].line,  openPositions[i].character));
+            expect(areas[i].end  ).toEqual(new Position(closePositions[i].line, closePositions[i].character));
+        }
+ 
+        // Sanity: areas are in strictly ascending order
+        const startOffsets = areas.map(a => document.offsetAt(a.start));
+        expect(startOffsets).toEqual([...startOffsets].sort((a, b) => a - b));
     });
 });
 

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -1,3 +1,8 @@
+// These tests focus on logic related to determining the proof status of an input area in the LeanLspClient.
+// These include the main logic of determineProofStatus, which combines diagnostic information and goal responses to classify an input area as Correct, Incorrect, or Invalid.
+// We also test the `getInputAreas` and `this.isBusy` logic since it is a key dependency of determineProofStatus, and the proof status logic relies on the areas being returned in document order.
+// The tests use a lot of mocking and test doubles since we want to isolate the logic of determineProofStatus and not depend on the full behavior of the LanguageClient or actual LSP communication.
+
 jest.mock("vscode", () => {
     const Position = class {
         constructor(public line: number, public character: number) {}
@@ -346,6 +351,8 @@ describe("LeanLspClient.determineProofStatus", () => {
     });
 });
 
+// The most important test is the order in which the input areas are returned, since the proof status logic assumes they are in document order. 
+// The other tests just verify that the getInputAreas logic correctly identifies the start and end of input areas in various scenarios.
 describe("LeanLspClient.getInputAreas", () => {
  
     it("returns an empty array when there are no input areas", () => {

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -331,6 +331,19 @@ describe("LeanLspClient.determineProofStatus", () => {
         jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
         expect(await call(instance, [msgDiag("declaration uses 'sorry'", 6, 0)])).toBe(InputAreaStatus.Invalid);
     });
+
+    it("returns Correct when a 'declaration uses sorry' diagnostic is Information severity (not Warning), prevents the user from doing: \"#check declaration uses 'sorry'\"", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        
+        const infoSorryDiag = {
+            message:  "declaration uses 'sorry'",
+            severity: DiagnosticSeverity.Information,
+            range: new Range(new Position(4, 0), new Position(4, 0)),
+        };
+    
+        expect(await call(instance, [infoSorryDiag])).toBe(InputAreaStatus.Correct);
+    });
 });
 
 describe("LeanLspClient.getInputAreas", () => {

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -67,16 +67,25 @@ jest.mock("vscode-languageserver-types", () => ({
 
 jest.mock("../../../shared",        () => ({ MessageType: {}, FileProgressKind: { Processing: 1 } }), { virtual: true });
 jest.mock("../../../lib/types",     () => ({}), { virtual: true });
-jest.mock("../../helpers",          () => ({
+jest.mock("../../../src/helpers",   () => ({
     WaterproofConfigHelper: { get: jest.fn(() => false) },
     WaterproofLogger:       { log: jest.fn(), debug: jest.fn() },
     WaterproofSetting:      {},
     qualifiedSettingName:   jest.fn(s => s),
-}), { virtual: true });
+}));
 jest.mock("../sentenceManager",     () => ({ SentenceManager: class { onProgress() {} dispose() {} } }), { virtual: true });
 jest.mock("../clientTypes",         () => ({}), { virtual: true });
 jest.mock("../requestTypes",        () => ({ convertToSimple: jest.fn() }), { virtual: true });
-jest.mock("../qedStatus",           () => ({ findOccurrences: jest.fn(() => []) }), { virtual: true });
+jest.mock("../qedStatus",           () => ({
+    findOccurrences: jest.fn((substr: string, str: string) => {
+        const indices: number[] = [];
+        const substrLen = substr.length;
+        for (let i = 0; (i = str.indexOf(substr, i)) >= 0; i += substrLen) {
+            indices.push(i);
+        }
+        return indices;
+    }),
+}), { virtual: true });
 jest.mock("./requestTypes",         () => ({
     leanFileProgressNotificationType: "$/lean/fileProgress",
     leanGoalRequestType:              "$/lean/plainGoal",
@@ -149,6 +158,13 @@ const messageDiag = (message: string, startLine: number, startCharacter = 0) => 
         new Position(startLine, startCharacter),
     ),
 });
+
+const makeDocument = (content: string) => ({
+    ...FAKE_DOCUMENT,
+    getText:    () => content,
+    positionAt: (offset: number) => new Position(0, offset),
+    offsetAt:   (pos: any) => pos.character,
+}) as any;
 
 // ===========================================================================
 // Tests
@@ -272,6 +288,138 @@ describe("LeanLspClient.earlyProofStatus", () => {
         expect(earlyProofStatus([
             messageDiag("Try these:\n  exact h\n\ndeclaration uses 'sorry'", 4),
         ])).toBe(InputAreaStatus.Incorrect);
+    });
+});
+
+describe("LeanLspClient.getInputAreas ordering", () => {
+    it("returns input areas in source order", () => {
+        const instance = makeClient();
+        const content = [
+            "before",
+            ":::input",
+            "first",
+            ":::",
+            "between",
+            ":::input",
+            "second",
+            ":::",
+            "",
+        ].join("\n");
+        const document = makeDocument(content);
+
+        // @ts-expect-error protected
+        const areas = instance.getInputAreas(document) as Range[];
+        expect(areas).toHaveLength(2);
+
+        const starts = areas.map(area => document.offsetAt(area.start));
+        const firstOpen = content.indexOf(":::input\n");
+        const secondOpen = content.indexOf(":::input\n", firstOpen + 1);
+
+        expect(starts).toEqual([firstOpen, secondOpen]);
+        expect(starts).toEqual([...starts].sort((a, b) => a - b));
+    });
+
+    it("keeps consecutive areas monotonic for lower-bound logic", () => {
+        const instance = makeClient();
+        const content = [
+            ":::input",
+            "a",
+            ":::",
+            ":::input",
+            "b",
+            ":::",
+            ":::input",
+            "c",
+            ":::",
+            "",
+        ].join("\n");
+        const document = makeDocument(content);
+
+        // @ts-expect-error protected
+        const areas = instance.getInputAreas(document) as Range[];
+        expect(areas).toHaveLength(3);
+
+        const starts = areas.map(area => document.offsetAt(area.start));
+        const ends = areas.map(area => document.offsetAt(area.end));
+
+        for (let i = 1; i < areas.length; i++) {
+            expect(starts[i]).toBeGreaterThan(starts[i - 1]);
+            expect(ends[i - 1]).toBeLessThanOrEqual(starts[i]);
+        }
+    });
+
+    it("stays sorted on production-like multilean content", () => {
+        const instance = makeClient();
+        const content = [
+            "#doc (WaterproofGenre) \"Index\" =>",
+            "",
+            "::::multilean",
+            "",
+            "## ATC - 003",
+            "```lean",
+            "Example \"ATC - 003\"",
+            "  Given:",
+            "  Assume:",
+            "  Conclusion: ∀ a : ℝ, ∀ b > 5, ∃ c, c > b - a",
+            "Proof:",
+            "```",
+            ":::input",
+            "```lean",
+            "",
+            "```",
+            ":::",
+            "",
+            "## ATC - 009",
+            ":::hint \"Show hint\"",
+            "  hello",
+            ":::",
+            "```lean",
+            "Example \"ATC - 009\"",
+            "  Given:",
+            "  Assume:",
+            "  Conclusion: ∀ a : ℝ, ∀ b > 5, ∃ c, c > b - a",
+            "Proof:",
+            "```",
+            ":::input",
+            "```lean",
+            "",
+            "```",
+            ":::",
+            "",
+            "## ATC - 014",
+            "```lean",
+            "Example \"ATC - 014\"",
+            "  Given: (f : ℝ → ℝ) (u : ℕ → ℝ) (x₀ : ℝ)",
+            "  Assume: (hu : u converges to x₀) (hf : f is continuous at x₀)",
+            "  Conclusion: (f ∘ u) converges to f x₀",
+            "Proof:",
+            "```",
+            ":::input",
+            "```lean",
+            "  Fix ε > 0",
+            "  By hf applied to ε using that ε > 0 we get δ such that",
+            "    (δ_pos : δ > 0) and (Hf : ∀ x, |x - x₀| ≤ δ ⇒ |f x - f x₀| ≤ ε)",
+            "```",
+            ":::",
+            "",
+            "::::",
+            "",
+        ].join("\n");
+        const document = makeDocument(content);
+
+        // @ts-expect-error protected
+        const areas = instance.getInputAreas(document) as Range[];
+        expect(areas.length).toBeGreaterThan(2);
+
+        const starts = areas.map(area => document.offsetAt(area.start));
+
+        const expectedOpenOffsets: number[] = [];
+        for (let i = 0; (i = content.indexOf(":::input\n", i)) >= 0; i += ":::input\n".length) {
+            expectedOpenOffsets.push(i);
+        }
+
+        expect(starts).toEqual(expectedOpenOffsets);
+        expect(starts).toEqual([...starts].sort((a, b) => a - b));
     });
 });
 

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -545,15 +545,6 @@ describe("LeanLspClient.isBusy lifecycle", () => {
         range: new Range(new Position(1, 0), new Position(2, 0)),
     }];
 
-    it("sets isBusy to true on document changes", () => {
-        const instance = makeClient(false);
-
-        // @ts-expect-error protected
-        instance.onDocumentChanged();
-
-        expect((instance as any).isBusy).toBe(true);
-    });
-
     it("sets isBusy to true when file progress reports processing", async () => {
         const instance = makeClient(false);
         jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
@@ -582,32 +573,5 @@ describe("LeanLspClient.isBusy lifecycle", () => {
         await instance.onFileProgress(progress([], "file:///other.lean"));
 
         expect((instance as any).isBusy).toBe(true);
-    });
-
-    it("clears isBusy when checking completes", async () => {
-        const instance = makeClient(true);
-        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
-
-        // @ts-expect-error protected
-        await instance.onCheckingCompleted();
-
-        expect((instance as any).isBusy).toBe(false);
-    });
-
-    it("does not get stuck busy after edit -> processing -> done sequence", async () => {
-        const instance = makeClient(false);
-        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
-
-        // @ts-expect-error protected
-        instance.onDocumentChanged();
-        expect((instance as any).isBusy).toBe(true);
-
-        // @ts-expect-error protected
-        await instance.onFileProgress(progress(processingRange()));
-        expect((instance as any).isBusy).toBe(true);
-
-        // @ts-expect-error protected
-        await instance.onCheckingCompleted();
-        expect((instance as any).isBusy).toBe(false);
     });
 });

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -8,6 +8,9 @@ jest.mock("vscode", () => {
             return this.line > other.line
                 || (this.line === other.line && this.character > other.character);
         }
+        isBeforeOrEqual(other: InstanceType<typeof Position>) {
+            return !this.isAfter(other);
+        }
     };
 
     const Range = class {
@@ -93,7 +96,8 @@ import { LeanLspClient } from "../../../src/lsp-client/lean/client";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const INPUT_AREA = new Range(new Position(0, 0), new Position(5, 0));
+const INPUT_AREA   = new Range(new Position(2, 0), new Position(6, 0));
+const LOWER_BOUND  = new Position(2, 0);
 
 const FAKE_DOCUMENT = {
     uri:        { toString: () => "file:///test.lean", path: "/test.lean" },
@@ -133,21 +137,25 @@ function makeClient(isBusy = false) {
     return instance;
 }
 
-const call = (instance: LeanLspClient, diags: any[] = [], area = INPUT_AREA) =>
-    (instance as any).determineProofStatus(FAKE_DOCUMENT, area, diags);
+const call = (
+    instance:   LeanLspClient,
+    diags:      any[]    = [],
+    area:       Range    = INPUT_AREA,
+    lower:      Position = LOWER_BOUND,
+) => (instance as any).determineProofStatus(FAKE_DOCUMENT, area, diags, lower);
 
+/** Creates a diagnostic with a given line range and severity. */
 const diag = (startLine: number, endLine: number, severity: number) => ({
     message:  "test",
     severity,
     range: new Range(new Position(startLine, 0), new Position(endLine, 0)),
 });
 
-const messageDiag = (message: string, startLine: number, startCharacter = 0) => ({
+/** Creates a diagnostic with a specific message (used for sorry / hint tests). */
+const msgDiag = (message: string, line: number, character = 0) => ({
     message,
-    range: new Range(
-        new Position(startLine, startCharacter),
-        new Position(startLine, startCharacter),
-    ),
+    severity: DiagnosticSeverity.Warning,      // severity is irrelevant for message checks
+    range: new Range(new Position(line, character), new Position(line, character)),
 });
 
 function makeDocument(content: string) {
@@ -188,7 +196,7 @@ function posOf(content: string, needle: string, fromOffset = 0) {
     const character = idx - before.lastIndexOf("\n") - 1;
     return { line, character, offset: idx };
 }
- 
+
  
 
 // ===========================================================================
@@ -196,40 +204,68 @@ function posOf(content: string, needle: string, fromOffset = 0) {
 // ===========================================================================
 describe("LeanLspClient.determineProofStatus", () => {
 
-    it("returns Incorrect when isBusy", async () => {
+    // ---- busy guard --------------------------------------------------------
+
+    it("returns Incorrect immediately when isBusy is true (no goal request made)", async () => {
         const instance = makeClient(true);
+        const requestGoals = jest.spyOn(instance, "requestGoals" as any);
+
         expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+        expect(requestGoals).not.toHaveBeenCalled();
     });
 
-    it("returns Incorrect for an Error diagnostic inside the area", async () => {
+    // ---- error diagnostics -------------------------------------------------
+
+    it("returns Incorrect when there is an Error diagnostic fully inside the area", async () => {
         const instance = makeClient();
         jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
-        expect(await call(instance, [diag(1, 3, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Incorrect);
+
+        expect(await call(instance, [diag(3, 5, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Incorrect);
     });
 
-    it("returns Incorrect for an Error diagnostic on the area boundary", async () => {
+    it("returns Incorrect when an Error diagnostic overlaps the area boundary", async () => {
         const instance = makeClient();
         jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
-        expect(await call(instance, [diag(4, 5, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Incorrect);
+
+        // range [5,7] intersects area [2,6]
+        expect(await call(instance, [diag(5, 7, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Incorrect);
     });
 
-    it("ignores an Error diagnostic outside the area", async () => {
+    it("ignores an Error diagnostic that lies entirely outside the area", async () => {
         const instance = makeClient();
         jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
-        expect(await call(instance, [diag(10, 11, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Correct);
+
+        expect(await call(instance, [diag(10, 12, DiagnosticSeverity.Error)])).toBe(InputAreaStatus.Correct);
     });
 
-    it("does not treat Warning/Info/Hint diagnostics as blocking", async () => {
+    it("does not treat Warning, Information, or Hint diagnostics as blocking", async () => {
         const instance = makeClient();
         jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+
         expect(await call(instance, [
-            diag(1, 2, DiagnosticSeverity.Warning),
-            diag(2, 3, DiagnosticSeverity.Information),
-            diag(3, 4, DiagnosticSeverity.Hint),
+            diag(3, 4, DiagnosticSeverity.Warning),
+            diag(4, 5, DiagnosticSeverity.Information),
+            diag(5, 6, DiagnosticSeverity.Hint),
         ])).toBe(InputAreaStatus.Correct);
     });
 
-    it("returns Incorrect when goals are non-empty", async () => {
+    // ---- goal response -----------------------------------------------------
+
+    it("returns Incorrect when the goals response is null", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue(null);
+
+        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("returns Incorrect when the goals response is undefined", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue(undefined);
+
+        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("returns Incorrect when the goals array is non-empty", async () => {
         const instance = makeClient();
         jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [{ type: "⊢ False" }] });
         expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
@@ -241,78 +277,59 @@ describe("LeanLspClient.determineProofStatus", () => {
         expect(await call(instance)).toBe(InputAreaStatus.Correct);
     });
 
-    it("returns Incorrect when requestGoals resolves with null", async () => {
+    // ---- sorry detection (Invalid) -----------------------------------------
+
+    it("returns Invalid when goals are empty but a sorry diagnostic is inside the area", async () => {
         const instance = makeClient();
-        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue(null);
-        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+
+        // line 4 is strictly inside [lowerBound=2, areaEnd=6]
+        expect(await call(instance, [msgDiag("declaration uses 'sorry'", 4)])).toBe(InputAreaStatus.Invalid);
     });
 
-    it("returns Incorrect when requestGoals resolves with undefined", async () => {
+    it("returns Correct when a sorry diagnostic sits exactly on lowerBound (not strictly after)", async () => {
         const instance = makeClient();
-        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue(undefined);
-        expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+
+        // line 2 == lowerBound.line, character 0 == lowerBound.character → not after → ignored
+        expect(await call(instance, [msgDiag("declaration uses 'sorry'", 2, 0)])).toBe(InputAreaStatus.Correct);
     });
 
-});
-
-describe("LeanLspClient.earlyProofStatus", () => {
-    const lowerBound = new Position(2, 0);
-    const inputArea = new Range(new Position(2, 0), new Position(6, 0));
-
-    const earlyProofStatus = (diags: any[]) => {
+    it("returns Correct when a sorry diagnostic is after the area end", async () => {
         const instance = makeClient();
-        // @ts-expect-error protected
-        return instance.earlyProofStatus(diags, lowerBound, inputArea);
-    };
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
 
-    it("returns Invalid for a sorry diagnostic inside bounds", () => {
-        expect(earlyProofStatus([
-            messageDiag("declaration uses 'sorry'", 4),
-        ])).toBe(InputAreaStatus.Invalid);
+        // line 7 > area end line 6
+        expect(await call(instance, [msgDiag("declaration uses 'sorry'", 7)])).toBe(InputAreaStatus.Correct);
     });
 
-    it("returns Incorrect for a Try these hint inside bounds", () => {
-        expect(earlyProofStatus([
-            messageDiag("Try these:\n  exact h", 4),
-        ])).toBe(InputAreaStatus.Incorrect);
+    it("returns Correct when a non-sorry message matches neither sorry nor hints", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+
+        expect(await call(instance, [msgDiag("type mismatch", 4)])).toBe(InputAreaStatus.Correct);
     });
 
-    it("returns null when matching diagnostic is at lowerBound", () => {
-        expect(earlyProofStatus([
-            messageDiag("declaration uses 'sorry'", 2, 0),
-        ])).toBeNull();
+    // ---- interaction between error diags and sorry -------------------------
+
+    it("returns Incorrect (not Invalid) when there is both an Error diag and a sorry diag in the area", async () => {
+        const instance = makeClient();
+        // requestGoals should not even be reached when an error diag is present
+        const requestGoals = jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+
+        const result = await call(instance, [
+            diag(3, 5, DiagnosticSeverity.Error),
+            msgDiag("declaration uses 'sorry'", 4),
+        ]);
+
+        expect(result).toBe(InputAreaStatus.Incorrect);
+        expect(requestGoals).not.toHaveBeenCalled();
     });
 
-    it("returns null when matching diagnostic is after input area end", () => {
-        expect(earlyProofStatus([
-            messageDiag("Try these:\n  simp", 7),
-        ])).toBeNull();
-    });
-
-    it("returns null for non-matching messages", () => {
-        expect(earlyProofStatus([
-            messageDiag("type mismatch", 4),
-        ])).toBeNull();
-    });
-
-    it("returns Invalid when only sorry matches among mixed diagnostics", () => {
-        expect(earlyProofStatus([
-            messageDiag("type mismatch", 4),
-            messageDiag("declaration uses 'sorry'", 5),
-        ])).toBe(InputAreaStatus.Invalid);
-    });
-
-    it("prioritizes Hint over sorry when both messages are present", () => {
-        expect(earlyProofStatus([
-            messageDiag("declaration uses 'sorry'", 4),
-            messageDiag("Try these:\n  exact h", 5),
-        ])).toBe(InputAreaStatus.Incorrect);
-    });
-
-    it("prioritizes Hint over sorry even within the same diagnostic message", () => {
-        expect(earlyProofStatus([
-            messageDiag("Try these:\n  exact h\n\ndeclaration uses 'sorry'", 4),
-        ])).toBe(InputAreaStatus.Incorrect);
+    it("returns Invalid when a sorry diagnostic sits exactly on inputArea.end (isBeforeOrEqual includes the boundary)", async () => {
+        const instance = makeClient();
+        jest.spyOn(instance, "requestGoals" as any).mockResolvedValue({ goals: [] });
+        expect(await call(instance, [msgDiag("declaration uses 'sorry'", 6, 0)])).toBe(InputAreaStatus.Invalid);
     });
 });
 

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -4,6 +4,10 @@ jest.mock("vscode", () => {
         translate(lineDelta: number, charDelta: number) {
             return new Position(this.line + lineDelta, this.character + charDelta);
         }
+        isAfter(other: InstanceType<typeof Position>) {
+            return this.line > other.line
+                || (this.line === other.line && this.character > other.character);
+        }
     };
 
     const Range = class {
@@ -120,6 +124,11 @@ function makeClient(isBusy = false) {
         { appendLine: jest.fn() } as any,
     );
     (instance as any).activeDocument = FAKE_DOCUMENT;
+    (instance as any).webviewManager = {
+        postMessage: jest.fn(),
+        postAndCacheMessage: jest.fn(),
+        has: jest.fn(() => true),
+    };
     (instance as any).isBusy = isBusy;
     return instance;
 }
@@ -131,6 +140,14 @@ const diag = (startLine: number, endLine: number, severity: number) => ({
     message:  "test",
     severity,
     range: new Range(new Position(startLine, 0), new Position(endLine, 0)),
+});
+
+const messageDiag = (message: string, startLine: number, startCharacter = 0) => ({
+    message,
+    range: new Range(
+        new Position(startLine, startCharacter),
+        new Position(startLine, startCharacter),
+    ),
 });
 
 // ===========================================================================
@@ -195,4 +212,129 @@ describe("LeanLspClient.determineProofStatus", () => {
         expect(await call(instance)).toBe(InputAreaStatus.Incorrect);
     });
 
+});
+
+describe("LeanLspClient.shouldMarkInvalid", () => {
+    const lowerBound = new Position(2, 0);
+    const inputArea = new Range(new Position(2, 0), new Position(6, 0));
+
+    const shouldMarkInvalid = (diags: any[]) => {
+        const instance = makeClient();
+        //@ts-expect-error private
+        return instance.shouldMarkInvalid(diags, lowerBound, inputArea);
+    };
+
+    it("returns true for a sorry diagnostic inside bounds", () => {
+        expect(shouldMarkInvalid([
+            messageDiag("declaration uses 'sorry'", 4),
+        ])).toBe(true);
+    });
+
+    it("returns true for a Try these hint inside bounds", () => {
+        expect(shouldMarkInvalid([
+            messageDiag("Try these:\n  exact h", 4),
+        ])).toBe(true);
+    });
+
+    it("returns false when matching diagnostic is at lowerBound", () => {
+        expect(shouldMarkInvalid([
+            messageDiag("declaration uses 'sorry'", 2, 0),
+        ])).toBe(false);
+    });
+
+    it("returns false when matching diagnostic is after input area end", () => {
+        expect(shouldMarkInvalid([
+            messageDiag("Try these:\n  simp", 7),
+        ])).toBe(false);
+    });
+
+    it("returns false for non-matching messages", () => {
+        expect(shouldMarkInvalid([
+            messageDiag("type mismatch", 4),
+        ])).toBe(false);
+    });
+
+    it("returns true when any diagnostic matches among mixed diagnostics", () => {
+        expect(shouldMarkInvalid([
+            messageDiag("type mismatch", 4),
+            messageDiag("declaration uses 'sorry'", 5),
+        ])).toBe(true);
+    });
+});
+
+describe("LeanLspClient.isBusy lifecycle", () => {
+    const progress = (processing: any[], uri = "file:///test.lean") => ({
+        textDocument: { uri, version: 1 },
+        processing,
+    });
+
+    const processingRange = () => [{
+        range: new Range(new Position(1, 0), new Position(2, 0)),
+    }];
+
+    it("sets isBusy to true on document changes", () => {
+        const instance = makeClient(false);
+
+        // @ts-expect-error protected
+        instance.onDocumentChanged();
+
+        expect((instance as any).isBusy).toBe(true);
+    });
+
+    it("sets isBusy to true when file progress reports processing", async () => {
+        const instance = makeClient(false);
+        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
+
+        // @ts-expect-error protected
+        await instance.onFileProgress(progress(processingRange()));
+
+        expect((instance as any).isBusy).toBe(true);
+    });
+
+    it("sets isBusy to false when file progress has no processing ranges", async () => {
+        const instance = makeClient(true);
+        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
+
+        // @ts-expect-error protected
+        await instance.onFileProgress(progress([]));
+
+        expect((instance as any).isBusy).toBe(false);
+    });
+
+    it("does not change isBusy for progress notifications of another document", async () => {
+        const instance = makeClient(true);
+        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
+
+        // @ts-expect-error protected
+        await instance.onFileProgress(progress([], "file:///other.lean"));
+
+        expect((instance as any).isBusy).toBe(true);
+    });
+
+    it("clears isBusy when checking completes", async () => {
+        const instance = makeClient(true);
+        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
+
+        // @ts-expect-error protected
+        await instance.onCheckingCompleted();
+
+        expect((instance as any).isBusy).toBe(false);
+    });
+
+    it("does not get stuck busy after edit -> processing -> done sequence", async () => {
+        const instance = makeClient(false);
+        jest.spyOn(instance as any, "computeInputAreaStatus").mockResolvedValue(undefined);
+
+        // @ts-expect-error protected
+        instance.onDocumentChanged();
+        expect((instance as any).isBusy).toBe(true);
+
+        // @ts-expect-error protected
+        await instance.onFileProgress(progress(processingRange()));
+        expect((instance as any).isBusy).toBe(true);
+
+        // @ts-expect-error protected
+        await instance.onCheckingCompleted();
+        expect((instance as any).isBusy).toBe(false);
+    });
 });

--- a/__tests__/lsp-client/lean/client.proofStatus.test.ts
+++ b/__tests__/lsp-client/lean/client.proofStatus.test.ts
@@ -214,51 +214,64 @@ describe("LeanLspClient.determineProofStatus", () => {
 
 });
 
-describe("LeanLspClient.shouldMarkInvalid", () => {
+describe("LeanLspClient.earlyProofStatus", () => {
     const lowerBound = new Position(2, 0);
     const inputArea = new Range(new Position(2, 0), new Position(6, 0));
 
-    const shouldMarkInvalid = (diags: any[]) => {
+    const earlyProofStatus = (diags: any[]) => {
         const instance = makeClient();
-        //@ts-expect-error private
-        return instance.shouldMarkInvalid(diags, lowerBound, inputArea);
+        // @ts-expect-error protected
+        return instance.earlyProofStatus(diags, lowerBound, inputArea);
     };
 
-    it("returns true for a sorry diagnostic inside bounds", () => {
-        expect(shouldMarkInvalid([
+    it("returns Invalid for a sorry diagnostic inside bounds", () => {
+        expect(earlyProofStatus([
             messageDiag("declaration uses 'sorry'", 4),
-        ])).toBe(true);
+        ])).toBe(InputAreaStatus.Invalid);
     });
 
-    it("returns true for a Try these hint inside bounds", () => {
-        expect(shouldMarkInvalid([
+    it("returns Incorrect for a Try these hint inside bounds", () => {
+        expect(earlyProofStatus([
             messageDiag("Try these:\n  exact h", 4),
-        ])).toBe(true);
+        ])).toBe(InputAreaStatus.Incorrect);
     });
 
-    it("returns false when matching diagnostic is at lowerBound", () => {
-        expect(shouldMarkInvalid([
+    it("returns null when matching diagnostic is at lowerBound", () => {
+        expect(earlyProofStatus([
             messageDiag("declaration uses 'sorry'", 2, 0),
-        ])).toBe(false);
+        ])).toBeNull();
     });
 
-    it("returns false when matching diagnostic is after input area end", () => {
-        expect(shouldMarkInvalid([
+    it("returns null when matching diagnostic is after input area end", () => {
+        expect(earlyProofStatus([
             messageDiag("Try these:\n  simp", 7),
-        ])).toBe(false);
+        ])).toBeNull();
     });
 
-    it("returns false for non-matching messages", () => {
-        expect(shouldMarkInvalid([
+    it("returns null for non-matching messages", () => {
+        expect(earlyProofStatus([
             messageDiag("type mismatch", 4),
-        ])).toBe(false);
+        ])).toBeNull();
     });
 
-    it("returns true when any diagnostic matches among mixed diagnostics", () => {
-        expect(shouldMarkInvalid([
+    it("returns Invalid when only sorry matches among mixed diagnostics", () => {
+        expect(earlyProofStatus([
             messageDiag("type mismatch", 4),
             messageDiag("declaration uses 'sorry'", 5),
-        ])).toBe(true);
+        ])).toBe(InputAreaStatus.Invalid);
+    });
+
+    it("prioritizes Hint over sorry when both messages are present", () => {
+        expect(earlyProofStatus([
+            messageDiag("declaration uses 'sorry'", 4),
+            messageDiag("Try these:\n  exact h", 5),
+        ])).toBe(InputAreaStatus.Incorrect);
+    });
+
+    it("prioritizes Hint over sorry even within the same diagnostic message", () => {
+        expect(earlyProofStatus([
+            messageDiag("Try these:\n  exact h\n\ndeclaration uses 'sorry'", 4),
+        ])).toBe(InputAreaStatus.Incorrect);
     });
 });
 

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -220,7 +220,7 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
         this.computeInputAreaStatus(document);
     }
 
-    protected abstract determineProofStatus(document: TextDocument, inputArea: Range, diagnostics: Array<Diagnostic>): Promise<InputAreaStatus>;
+    protected abstract determineProofStatus(document: TextDocument, inputArea: Range, diagnostics: Array<Diagnostic>, lowerBound: Position): Promise<InputAreaStatus>;
 
     protected abstract getInputAreas(document: TextDocument): Range[] | undefined;
 
@@ -249,20 +249,13 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                     const lowerBound = i === 0
                         ? new Position(0, 0)
                         : inputAreas[i - 1].end;
-                    
-                    // Check if there are errors before the input area.
-                    // e.g. when using `sorry` in Lean. 
-                    const earlyStatus = this.earlyProofStatus(diags, lowerBound, area);
-                    if (earlyStatus !== null) {
-                        return Promise.resolve(earlyStatus);
-                    }
 
                     if (this.viewPortBasedChecking && this.viewPortRange && area.intersection(this.viewPortRange) === undefined) {
                         // This input area is outside of the range that has been checked and thus we can't determine its status
                         return Promise.resolve(InputAreaStatus.OutOfView);
                     }
 
-                    return this.determineProofStatus(document, area, diags);
+                    return this.determineProofStatus(document, area, diags, lowerBound);
                 }));
 
                 // forward statuses to corresponding ProseMirror editor
@@ -275,25 +268,6 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                 console.log("[computeInputAreaStatus] The catch block caught an error that we don't classify as 'cancelled by server':", reason);
             }
         }, 250);
-    }
-
-    /**
-     * Override in subclasses to short-circuit proof checking with Invalid
-     * before the LSP goals request is made. Called once per input area with
-     * the diagnostics, the lower boundary (end of the previous input area),
-     * and the current area's range.
-     *
-     * Default returns null (no early-out).
-     * @param diags Diagnostics for the whole document.
-     * @param lowerBound The end position of the previous input area, or (0, 0) for the first input area.
-     * @param inputArea The range of the current input area.
-     */
-    protected earlyProofStatus(
-        _diags: Diagnostic[],
-        _lowerBound: Position,
-        _inputArea: Range
-    ): InputAreaStatus | null {
-        return null;
     }
 
     async startWithHandlers(webviewManager: WebviewManager, allowedLanguages: string[]): Promise<string[]> {

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -283,8 +283,6 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                 webviewManager.has(event.document.uri.toString())
                 && event.document.languageId === this.language
             ) {
-                this.onDocumentChanged();
-
                 this.updateCompletions(event.document);
             }
         }));
@@ -305,12 +303,6 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
     abstract requestGoals(position: Position): Promise<GoalAnswerT | null>;
     /** Sends an LSP request to retrieve the goals at the active cursor position. */
     abstract requestGoals(): Promise<GoalAnswerT | null>;
-
-    /**
-     * Called when the active document changes. Subclasses can use this to
-     * update any state that depends on the document being up to date.
-     */
-    protected abstract onDocumentChanged(): void;
 
     async requestSymbols(document?: TextDocument): Promise<DocumentSymbol[]> {
         // use active document if no document is given

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -227,7 +227,7 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
     // This setTimeout creates a NodeJS.Timeout object, but in the browser it is just a number.
     computeInputAreaStatusTimer?: NodeJS.Timeout | number;
 
-    protected async computeInputAreaStatus(document: TextDocument) {
+    protected async computeInputAreaStatus(document: TextDocument): Promise<void> {
         if (this.computeInputAreaStatusTimer) {
             clearTimeout(this.computeInputAreaStatusTimer);
         }
@@ -244,13 +244,24 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
 
             // for each input area, check the proof status
             try {
-                const statuses = await Promise.all(inputAreas.map(a => {
-                    if (this.viewPortBasedChecking && this.viewPortRange && a.intersection(this.viewPortRange) === undefined) {
+                const statuses = await Promise.all(inputAreas.map((area, i) => {
+                    // compute lower bound for this input area: end of previous input area, or (0, 0) for the first one
+                    const lowerBound = i === 0
+                        ? new Position(0, 0)
+                        : inputAreas[i - 1].end;
+                    
+                    // Check if there are errors before the input area.
+                    // e.g. when using `sorry` in Lean. 
+                    if (this.shouldMarkInvalid(diags, lowerBound, area)) {
+                        return Promise.resolve(InputAreaStatus.Invalid);
+                    }
+
+                    if (this.viewPortBasedChecking && this.viewPortRange && area.intersection(this.viewPortRange) === undefined) {
                         // This input area is outside of the range that has been checked and thus we can't determine its status
                         return Promise.resolve(InputAreaStatus.OutOfView);
-                    } else {
-                        return this.determineProofStatus(document, a, diags);
                     }
+
+                    return this.determineProofStatus(document, area, diags);
                 }));
 
                 // forward statuses to corresponding ProseMirror editor
@@ -263,6 +274,25 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                 console.log("[computeInputAreaStatus] The catch block caught an error that we don't classify as 'cancelled by server':", reason);
             }
         }, 250);
+    }
+
+    /**
+     * Override in subclasses to short-circuit proof checking with Invalid
+     * before the LSP goals request is made. Called once per input area with
+     * the diagnostics, the lower boundary (end of the previous input area),
+     * and the current area's range.
+     *
+     * Default returns false (no early-out).
+     * @param diags Diagnostics for the whole document.
+     * @param lowerBound The end position of the previous input area, or (0, 0) for the first input area.
+     * @param inputArea The range of the current input area.
+     */
+    protected shouldMarkInvalid(
+        _diags: Diagnostic[],
+        _lowerBound: Position,
+        _inputArea: Range
+    ): boolean {
+        return false;
     }
 
     async startWithHandlers(webviewManager: WebviewManager, allowedLanguages: string[]): Promise<string[]> {

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -252,8 +252,9 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
                     
                     // Check if there are errors before the input area.
                     // e.g. when using `sorry` in Lean. 
-                    if (this.shouldMarkInvalid(diags, lowerBound, area)) {
-                        return Promise.resolve(InputAreaStatus.Invalid);
+                    const earlyStatus = this.earlyProofStatus(diags, lowerBound, area);
+                    if (earlyStatus !== null) {
+                        return Promise.resolve(earlyStatus);
                     }
 
                     if (this.viewPortBasedChecking && this.viewPortRange && area.intersection(this.viewPortRange) === undefined) {
@@ -282,17 +283,17 @@ export abstract class LspClient<GoalRequestT extends GoalRequest, GoalAnswerT ex
      * the diagnostics, the lower boundary (end of the previous input area),
      * and the current area's range.
      *
-     * Default returns false (no early-out).
+     * Default returns null (no early-out).
      * @param diags Diagnostics for the whole document.
      * @param lowerBound The end position of the previous input area, or (0, 0) for the first input area.
      * @param inputArea The range of the current input area.
      */
-    protected shouldMarkInvalid(
+    protected earlyProofStatus(
         _diags: Diagnostic[],
         _lowerBound: Position,
         _inputArea: Range
-    ): boolean {
-        return false;
+    ): InputAreaStatus | null {
+        return null;
     }
 
     async startWithHandlers(webviewManager: WebviewManager, allowedLanguages: string[]): Promise<string[]> {

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -252,12 +252,5 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         this.clientStoppedEmitter.fire({message: 'Lean server has stopped', reason: ''});
     }
 
-    protected onDocumentChanged(): void {
-        this.isBusy = true;
-    }
 
-    protected override async onCheckingCompleted(): Promise<void> {
-        this.isBusy = false;
-        await super.onCheckingCompleted();
-    }
 }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -171,7 +171,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         });
     }
 
-    protected async determineProofStatus(document: TextDocument, inputArea: Range, diags: Array<Diagnostic>): Promise<InputAreaStatus> {
+    protected async determineProofStatus(document: TextDocument, inputArea: Range, diags: Array<Diagnostic>, lowerBound: Position,): Promise<InputAreaStatus> {
 
         // If Lean hasn't finished processing up to the end of this input area, an empty goals
         // response simply means "not checked yet" rather than "proof complete".  Guard against
@@ -181,6 +181,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
             return InputAreaStatus.Incorrect;
         }
 
+        // Get diagnostics that intersect with the input area, and check if any of them are error-level.
         const diagsInArea = diags.filter(v => {
             const intersection = inputArea.intersection(v.range);
             return intersection !== undefined && !intersection.isEmpty;
@@ -194,6 +195,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
             return InputAreaStatus.Incorrect;
         }
  
+        // Request goals
         const goalsPosition = inputArea.end.translate(0, 0);
         
         const goalsParams = this.createGoalsRequestParameters(document, goalsPosition);
@@ -203,29 +205,18 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
             return InputAreaStatus.Incorrect;
         }
         
-        const status = response.goals.length > 0 ? InputAreaStatus.Incorrect : InputAreaStatus.Correct;
-        return status;
-    }
+        // return incorrect if there are still goals remaining
+        if (response.goals.length > 0) return InputAreaStatus.Incorrect;
 
-    private static readonly SORRY_RE = /declaration uses 'sorry'/m;
-    private static readonly HINT_RE = /^Try these:/m;
+        // Goals are empty, proof looks complete, but check for sorry
+        const SORRY_RE = /declaration uses 'sorry'/m;
 
-    protected earlyProofStatus(
-        diags: Diagnostic[],
-        lowerBound: Position,
-        inputArea: Range
-    ): InputAreaStatus | null {
-        const inRange = (d: Diagnostic) =>
+        const hasSorry = diags.some(d =>
             d.range.start.isAfter(lowerBound) &&
-            !d.range.start.isAfter(inputArea.end);
-
-        if (diags.some(d => LeanLspClient.HINT_RE.test(d.message) && inRange(d)))
-            return InputAreaStatus.Incorrect;
-
-        if (diags.some(d => LeanLspClient.SORRY_RE.test(d.message) && inRange(d)))
-            return InputAreaStatus.Invalid;
-
-        return null;
+            d.range.start.isBeforeOrEqual(inputArea.end) &&
+            SORRY_RE.test(d.message)
+        );
+        return hasSorry ? InputAreaStatus.Invalid : InputAreaStatus.Correct;
     }
 
     // Emitters for infoview

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -209,13 +209,14 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         if (response.goals.length > 0) return InputAreaStatus.Incorrect;
 
         // Goals are empty, proof looks complete, but check for sorry
-        const SORRY_RE = "declaration uses 'sorry'";
+        // The Lean LSP prefixes all sorry-like aliases with "declaration uses "
+        const SORRY_PREFIX = "declaration uses ";
 
         const hasSorry = diags.some(d =>
             d.severity === DiagnosticSeverity.Warning &&
             d.range.start.isAfter(lowerBound) &&
             d.range.start.isBeforeOrEqual(inputArea.end) &&
-            SORRY_RE === d.message
+            d.message.startsWith(SORRY_PREFIX)
         );
         return hasSorry ? InputAreaStatus.Invalid : InputAreaStatus.Correct;
     }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -207,6 +207,22 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         return status;
     }
 
+    private static readonly SORRY_HINT_RE = /declaration uses 'sorry'|^Try these:/m;
+
+    protected shouldMarkInvalid(
+        diags: Diagnostic[],
+        lowerBound: Position,
+        inputArea: Range
+    ): boolean {
+        // Is there a `sorry` or a `hint` error after the end of the previous input area
+        // and before the end of the current input area?
+        return diags.some(d =>
+            LeanLspClient.SORRY_HINT_RE.test(d.message) &&
+            d.range.start.isAfter(lowerBound) &&
+            !d.range.start.isAfter(inputArea.end)
+        );
+    }
+
     // Emitters for infoview
     private didChangeEmitter = new EventEmitter<DidChangeTextDocumentParams>();
     public didChange(cb: (params: DidChangeTextDocumentParams) => void): Disposable {
@@ -242,5 +258,10 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
 
     protected onDocumentChanged(): void {
         this.isBusy = true;
+    }
+
+    protected override async onCheckingCompleted(): Promise<void> {
+        this.isBusy = false;
+        await super.onCheckingCompleted();
     }
 }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -209,7 +209,9 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         if (response.goals.length > 0) return InputAreaStatus.Incorrect;
 
         // Goals are empty, proof looks complete, but check for sorry
-        // The Lean LSP prefixes all sorry-like aliases with "declaration uses "
+        // The Lean LSP prefixes all sorry-like aliases with "declaration uses " including hint
+        // Important: when hint suggests something that immediatly resolves the goal,
+        // it will not throw a sorry warning. It will see the proof as valid.
         const SORRY_PREFIX = "declaration uses ";
 
         const hasSorry = diags.some(d =>

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -207,20 +207,25 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         return status;
     }
 
-    private static readonly SORRY_HINT_RE = /declaration uses 'sorry'|^Try these:/m;
+    private static readonly SORRY_RE = /declaration uses 'sorry'/m;
+    private static readonly HINT_RE = /^Try these:/m;
 
-    protected shouldMarkInvalid(
+    protected earlyProofStatus(
         diags: Diagnostic[],
         lowerBound: Position,
         inputArea: Range
-    ): boolean {
-        // Is there a `sorry` or a `hint` error after the end of the previous input area
-        // and before the end of the current input area?
-        return diags.some(d =>
-            LeanLspClient.SORRY_HINT_RE.test(d.message) &&
+    ): InputAreaStatus | null {
+        const inRange = (d: Diagnostic) =>
             d.range.start.isAfter(lowerBound) &&
-            !d.range.start.isAfter(inputArea.end)
-        );
+            !d.range.start.isAfter(inputArea.end);
+
+        if (diags.some(d => LeanLspClient.HINT_RE.test(d.message) && inRange(d)))
+            return InputAreaStatus.Incorrect;
+
+        if (diags.some(d => LeanLspClient.SORRY_RE.test(d.message) && inRange(d)))
+            return InputAreaStatus.Invalid;
+
+        return null;
     }
 
     // Emitters for infoview

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -209,12 +209,13 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         if (response.goals.length > 0) return InputAreaStatus.Incorrect;
 
         // Goals are empty, proof looks complete, but check for sorry
-        const SORRY_RE = /declaration uses 'sorry'/m;
+        const SORRY_RE = "declaration uses 'sorry'";
 
         const hasSorry = diags.some(d =>
+            d.severity === DiagnosticSeverity.Warning &&
             d.range.start.isAfter(lowerBound) &&
             d.range.start.isBeforeOrEqual(inputArea.end) &&
-            SORRY_RE.test(d.message)
+            SORRY_RE === d.message
         );
         return hasSorry ? InputAreaStatus.Invalid : InputAreaStatus.Correct;
     }

--- a/src/lsp-client/rocq/client.ts
+++ b/src/lsp-client/rocq/client.ts
@@ -195,8 +195,4 @@ export class RocqLspClient extends LspClient<RocqGoalRequest, RocqGoalAnswer<PpS
         if (!this.activeCursorPosition) return undefined;
         return this.sentenceManager.getEndOfSentence(this.activeCursorPosition);
     }
-
-    protected onDocumentChanged(): void {
-        // Rocq tracks its own busy state via the coqServerStatus notification.
-    }
 }


### PR DESCRIPTION
### Description
`sorry` and `hint` were marking the input areas as Correct. This should fix it. `sorry` is now marked as Invalid. The ` This pull request also fixes an issue where the `isBusy` flag would sometimes not properly reset.

### Changes
When a user types `sorry`, Lean will not mark the input as using `sorry`, but will mark the theorem. This means that the message "deceleration uses `sorry`" will appear outside the input area. In order to link the input area with this message, we look if there are any `sorry` messages between the end of the current input area and the end of the previous one. Then we mark that input area as invalid. Same for `hint`, since it also sends `sorry` messages when used.

I also removed a mistake I made with the `isBusy` flag being set with this function called `onDocumentChanged`. This function shouldn't be in there any more, so I removed it. This fixes a bug where correct input area fields would stay permanently red, because `isBusy` wasn't being set to false. 

renamed `client.determineProofStatus.test.ts` to `client.proofStatus.test.ts` to be more inclusive of functions other than determineProofStatus.

### Testing this PR
- Open your favourite Lean document.
- Type `sorry` or `hint`.
- Observe that only the input area you selected is turning yellow
- Input areas that are correct should no longer stay red forever when typing in other input fields. (`isBusy`)

There are also a few automated unit tests. Most notably, this approach requires `getInputAreas` to return a sorted array, I have written tests to ensure that this is always the case


Closes #328