### PR TITLE
fix: accidentily copied the wrong switch statement into messageHandler.ts

### DIFF
--- a/__tests__/editor/messageHandler.test.ts
+++ b/__tests__/editor/messageHandler.test.ts
@@ -66,34 +66,18 @@ describe("handleEditorMessage", () => {
     });
 
     describe("progress", () => {
-        it("clears busy indicators and skips reportProgress when progress is empty", () => {
+        it("clears busy indicators and reports 'File verified' when progress is empty", () => {
             const editor = createEditorMock();
+            const numberOfLines = 12;
             const msg: Message = {
                 type: MessageType.progress,
-                body: { numberOfLines: 12, progress: [] },
+                body: { numberOfLines, progress: [] },
             };
 
             handleEditorMessage(editor, msg);
 
             expect(editor.removeBusyIndicators).toHaveBeenCalledTimes(1);
-            expect(editor.reportProgress).not.toHaveBeenCalled();
-        });
-
-        it("reports 'File verified' when progress has reached the last line", () => {
-            const editor = createEditorMock();
-            const numberOfLines = 50;
-            const msg: Message = {
-                type: MessageType.progress,
-                body: {
-                    numberOfLines,
-                    progress: [{ range: { start: { line: numberOfLines - 1, character: 0 }, end: { line: numberOfLines - 1, character: 0 } } }],
-                },
-            };
-
-            handleEditorMessage(editor, msg);
-
             expect(editor.reportProgress).toHaveBeenCalledWith(numberOfLines, numberOfLines, "File verified");
-            expect(editor.removeBusyIndicators).not.toHaveBeenCalled();
         });
 
         it("reports partial progress message when not yet on the last line", () => {

--- a/editor/src/messageHandler.ts
+++ b/editor/src/messageHandler.ts
@@ -78,13 +78,9 @@ export function handleEditorMessage(editor: MessageHandlerEditor, msg: Message):
 				const { numberOfLines, progress } = msg.body;
 				if (progress.length === 0) {
 					editor.removeBusyIndicators();
-					break;
-				}
-
-				const at = progress[0].range.start.line + 1;
-				if (at === numberOfLines) {
-					editor.reportProgress(at, numberOfLines, "File verified");
+					editor.reportProgress(numberOfLines, numberOfLines, "File verified");
 				} else {
+					const at = progress[0].range.start.line + 1;
 					editor.reportProgress(at, numberOfLines, `Verified file up to line: ${at}`);
 				}
 				break;


### PR DESCRIPTION
I messed up :(  In PR #336, I accidentally copied the buggy version into messageHandler.ts, which meant the file progress bar still got stuck. I replaced it with the fixed version and updated the tests.
