### PR TITLE
Add pos argument to tryStep and return range of proof via proofContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "waterproof",
   "displayName": "Waterproof",
   "description": "Waterproof for VSC",
-  "version": "0.10.1",
+  "version": "0.11.1",
   "waterproofConfiguration": {
     "requiredCoqLspVersion": ">=0.2.4",
     "requiredCoqWaterproofVersion": ">=3.1.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { Position, TextDocument } from "vscode";
+import { Position, Range, TextDocument } from "vscode";
 import { RunResult } from "./lsp-client/petanque";
 import { GoalConfig } from "../lib/types";
 
@@ -9,10 +9,11 @@ export type WaterproofAPI = {
     proofContext: (cursorMarker: string) => Promise<{ 
         name: string,
         full: string,
-        withCursorMarker: string
+        withCursorMarker: string,
+        proofRange: Range
     }>;
     execCommand: (cmd: string) => Promise<GoalConfig<string> & RunResult<number>>;
-    tryProof: (steps: string) => Promise<{finished: boolean, remainingGoals: string[]}>;
+    tryProof: (steps: string, pos?: Position) => Promise<{finished: boolean, remainingGoals: string[]}>;
     cursorPosition: () => Position | undefined;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,8 @@ import {
     workspace,
     window,
     ConfigurationTarget,
-    Uri} from "vscode";
+    Uri,
+    Range} from "vscode";
 import { LanguageClientOptions, RevealOutputChannelOn } from "vscode-languageclient";
 
 import { IExecutor, IGoalsComponent, IStatusComponent } from "./components";
@@ -347,7 +348,8 @@ export class Waterproof implements Disposable {
     public async proofContext(cursorMarker: string = "{!* CURSOR *!}"): Promise<{
         name: string,
         full: string
-        withCursorMarker: string
+        withCursorMarker: string,
+        proofRange: Range
     }> {
         if (!this.client.activeDocument || !this.client.activeCursorPosition) {
             throw new Error("No active document or cursor position.");
@@ -359,6 +361,7 @@ export class Waterproof implements Disposable {
 
         // Regex to find the end of the proof the user is working on.
         const endRegex = /(?:Qed|Admitted|Defined)\.\s/;
+        
         // We request the document symbols with the goal of finding the lemma the user is working on.
         const symbols = await this.client.requestSymbols();
         const firstBefore = symbols.filter(s => {
@@ -369,19 +372,27 @@ export class Waterproof implements Disposable {
         if (firstBefore === undefined) {
             throw new Error("Could not find lemma before cursor.");
         }
+        const startRegex = new RegExp(`(?:Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\\s+${firstBefore.name}\\s*:\\s*[^.]*\\.\\s+(?:Proof\\.)?`, "g");
         // Compute the offset into the document where the proof starts (will be the position before Lemma)
         const startProof = document.offsetAt(new Position(firstBefore.range.start.line, firstBefore.range.start.character));
 
         // Get the part of the text of the document starting at the lemma statement.
         const docText = document.getText().substring(startProof);
-        const proofClose = docText.match(endRegex);
+        const proofClose = endRegex.exec(docText);
 
         if (proofClose === null) {
             throw new Error("Could not find end of proof.");
         }
 
-        // Get the text of the proof from the document, we need to add startProof to the index since the regex was run on a su
-        const theProof = docText.substring(0, proofClose.index! + proofClose[0].length);
+        const startMatch = startRegex.exec(docText);
+        if (startMatch === null) {
+            throw new Error("Could not find start of proof.");
+        }
+        const proofStart = startProof + startMatch.index + startMatch[0].length;
+
+
+        // Get the text of the proof from the document
+        const theProof = docText.substring(0, proofClose.index + proofClose[0].length);
 
         // Helper function to remove input-area tags, coq markers and extra whitespace from input string
         const removeMarkersAndWhitespace = (input: string) => {
@@ -397,17 +408,19 @@ export class Waterproof implements Disposable {
         return {
             full: removeMarkersAndWhitespace(theProof),
             withCursorMarker: removeMarkersAndWhitespace(theProof.substring(0, offsetIntoMatch) + cursorMarker + theProof.substring(offsetIntoMatch)),
-            name: firstBefore.name
+            name: firstBefore.name,
+            proofRange: new Range(document.positionAt(proofStart), document.positionAt(proofClose.index + startProof))
         }
     }
 
     /**
-     * Try a proof/step by executing the given commands/tactics.
+     * Try a proof/step by executing the given commands/tactics at the cursor position.
      * @param steps The proof steps to try. This can be a single tactic or command or multiple separated by the
      * usual `.` and space.
+     * @param pos Optional position at which to try the proof steps.
      */
-    public async tryProof(steps: string): Promise<{finished: boolean, remainingGoals: string[]}> {
-        const execResponse = await executeCommandFullOutput(this.client, steps);
+    public async tryProof(steps: string, pos?: Position): Promise<{finished: boolean, remainingGoals: string[]}> {
+        const execResponse = await executeCommandFullOutput(this.client, steps, pos);
         return {
             finished: execResponse.proof_finished,
             remainingGoals: execResponse.goals.map(g => convertToString(g.ty))

--- a/src/lsp-client/commandExecutor.ts
+++ b/src/lsp-client/commandExecutor.ts
@@ -7,20 +7,22 @@ import { GetStateAtPosParams, getStateAtPosReq, GoalParams, goalsReq, RunParams,
 /**
  * Base function for executing tactics/commands in a client.
  */
-async function executeCommandBase(client: CoqLspClient, command: string) {
+async function executeCommandBase(client: CoqLspClient, command: string, pos?: Position) {
     const document = client.activeDocument;
 
     if (!document) {
         throw new Error("Cannot execute command; there is no active document.");
     }
 
-    // We execute the command at the end of the previous sentence.
-    const commandPosition = client.getBeginningOfCurrentSentence();
-    if (!commandPosition) {
-        throw new Error("Cannot execute command; the document contains no Coq code.");
+    if (!pos) {
+        // We execute the command at the end of the previous sentence.
+        const commandPosition = client.getBeginningOfCurrentSentence();
+        if (!commandPosition) {
+            throw new Error("Cannot execute command; the document contains no Coq code.");
+        }
+        pos = new Position(commandPosition.line, commandPosition.character > 0 ? commandPosition.character - 1 : 0);
     }
 
-    const pos = { line: commandPosition.line, character: commandPosition.character - 1 };
     const params: GetStateAtPosParams = {
         // Make sure that the position is **before** the dot, otherwise there is no node at the position.
         position: pos,
@@ -49,12 +51,13 @@ async function executeCommandBase(client: CoqLspClient, command: string) {
  * Execute `command` using client `client` and return the output formatted as a valid `GoalAnswer<string>`.
  * @param client The client to use when executing the command.
  * @param command The command/tactic to execute. It is allowed to execute multiple tactics/commands by seperating them using `.`'s.
+ * @param pos Optional position at which to execute the command.
  * @returns The output of executing `command` formatted as a valid `GoalAnswer<string>` object, this can be passed to any component that
  * implement `IGoalsComponent`.
  */
-export async function executeCommand(client: CoqLspClient, command: string): Promise<GoalAnswer<string>> {
+export async function executeCommand(client: CoqLspClient, command: string, pos?: Position): Promise<GoalAnswer<string>> {
     try {
-        const { goalsRes, runRes, document } = await executeCommandBase(client, command);
+        const { goalsRes, runRes, document } = await executeCommandBase(client, command, pos);
         // This should form a valid `GoalAnswer<string>`
         return {
             messages: runRes.feedback.map((val) => { return { level: val[0], text: val[1] } }),
@@ -72,11 +75,12 @@ export async function executeCommand(client: CoqLspClient, command: string): Pro
  * running the command (`RunResult`, this includes messages and whether the proof was finished running `command`)
  * @param client The client to use when executing the command.
  * @param command The command/tactic to execute. It is allowed to execute multiple tactics/commands by seperating them using `.`'s.
+ * @param pos Optional position at which to execute the command.
  * @returns The full output of running `command` using `client`.
  */
-export async function executeCommandFullOutput(client: CoqLspClient, command: string): Promise<GoalConfig<string> & RunResult<number>> {
+export async function executeCommandFullOutput(client: CoqLspClient, command: string, pos?: Position): Promise<GoalConfig<string> & RunResult<number>> {
     try {
-        const { goalsRes, runRes } = await executeCommandBase(client, command);
+        const { goalsRes, runRes } = await executeCommandBase(client, command, pos);
         return { ...goalsRes, ...runRes };
     } catch (error) {
         throw new Error(`Error when trying to execute command '${command}': ${error}`);


### PR DESCRIPTION
- Bumps version to 0.11.1 (which is odd, so prerelease?)
- Adds the option of trying a proof step at a given position, by updating the API and executeCommandBase.
- proofContext now returns the range of the proof script (between `Proof.` and `Qed.`, but works for scripts without `Proof.` as well, see the regex)

