### PR TITLE
Fix adoption bug in rocq by removing insert support for goal panel

### DIFF
--- a/src/webviews/goalviews/goalsPanel.ts
+++ b/src/webviews/goalviews/goalsPanel.ts
@@ -4,16 +4,14 @@ import { WebviewEvents, WebviewState } from "../waterproofPanel";
 import { MessageType } from "../../../shared";
 import { GoalsBase } from "./goalsBase";
 import { IExecutor } from "../../components";
-import { PpString, RocqGoalAnswer } from "../../../lib/types";
 
 //the goals panel extends the GoalsBase class
 export class GoalsPanel extends GoalsBase implements IExecutor {
-  private previousGoal: RocqGoalAnswer<PpString> | undefined;
   private data: string[] = ["no results"];
 
   // constructor to define the name and to listen for webview events
   constructor(extensionUri: Uri, config: LspClientConfig) {
-    super(extensionUri, config, "goals", true);
+    super(extensionUri, config, "goals");
     this.on(WebviewEvents.change, () => {
       if (this.state === WebviewState.visible) {
         // TODO: show last goals?


### PR DESCRIPTION
### Description
This PR fixes a bug which seems to be accidentally introduced within a refactor by enabling insert support for the goal panel.

### Changes
- Fix the bug
- Removed unused code.

### Testing this PR
Use a rocq mv file and test it manually as stated in the issue #349.

