### PR TITLE
Add prelimary Yalep support

### DIFF
--- a/__tests__/lsp-client/lean/client.test.ts
+++ b/__tests__/lsp-client/lean/client.test.ts
@@ -408,9 +408,9 @@ describe("LeanLspClient.determineProofStatus", () => {
       ["before", "", ":::input", "  proof a", ":::", ""].join("\n"),
     );
 
-    expect(
-      await call(instance, [], INPUT_AREA, LOWER_BOUND, noMarkerDoc),
-    ).toBe(InputAreaStatus.Incorrect);
+    expect(await call(instance, [], INPUT_AREA, LOWER_BOUND, noMarkerDoc)).toBe(
+      InputAreaStatus.Incorrect,
+    );
     expect(requestGoals).not.toHaveBeenCalled();
   });
 

--- a/__tests__/lsp-client/lean/client.test.ts
+++ b/__tests__/lsp-client/lean/client.test.ts
@@ -166,6 +166,26 @@ const FAKE_DOCUMENT = {
   lineCount: 10,
 } as TextDocument;
 
+// A realistic document whose `offsetAt`/`positionAt` are consistent with its text, and which
+// places the proof-closing marker (`□`) in a `lean` block *after* the input area — mirroring
+// the Yalep/Verbose Lean layout. `determineProofStatus` searches the text for this marker, so
+// these tests need a document where the marker actually exists at a consistent offset.
+// INPUT_AREA = lines 2..6, LOWER_BOUND = line 2; the `□` marker sits on line 8.
+const PROOF_CONTENT = [
+  "before", // 0
+  "", // 1
+  ":::input", // 2  <- INPUT_AREA start
+  "  proof a", // 3
+  "  proof b", // 4
+  "  proof c", // 5
+  ":::", // 6  <- INPUT_AREA end
+  "```lean", // 7
+  "□", // 8  <- closing marker
+  "```", // 9
+  "", // 10
+].join("\n");
+const PROOF_DOCUMENT = makeDocument(PROOF_CONTENT);
+
 function makeClientDouble() {
   return {
     isRunning: jest.fn(() => true),
@@ -204,9 +224,10 @@ const call = (
   diags: Diagnostic[] = [],
   area: Range = INPUT_AREA,
   lower: Position = LOWER_BOUND,
+  document: TextDocument = PROOF_DOCUMENT,
 ) => {
   // @ts-expect-error protected
-  return instance.determineProofStatus(FAKE_DOCUMENT, area, diags, lower);
+  return instance.determineProofStatus(document, area, diags, lower);
 };
 
 /** Creates a diagnostic with a given line range and severity. */
@@ -357,6 +378,95 @@ describe("LeanLspClient.determineProofStatus", () => {
     const instance = makeClient();
     jest.spyOn(instance, "requestGoals").mockResolvedValue(goalAnswer([]));
     expect(await call(instance)).toBe(InputAreaStatus.Correct);
+  });
+
+  // ---- closing marker (□ / QED) ------------------------------------------
+
+  it("requests goals at the closing marker (after the □), not at the input-area boundary", async () => {
+    const instance = makeClient();
+    const requestGoals = jest
+      .spyOn(instance, "requestGoals")
+      .mockResolvedValue(goalAnswer([]));
+
+    await call(instance);
+
+    // The □ sits on line 8; goals must be requested just after it (not at area end, line 6).
+    expect(requestGoals).toHaveBeenCalledTimes(1);
+    const params = requestGoals.mock.calls[0][0] as unknown as {
+      position: { line: number };
+    };
+    expect(params.position.line).toBe(8);
+  });
+
+  it("returns Incorrect (without requesting goals) when there is no closing marker", async () => {
+    const instance = makeClient();
+    const requestGoals = jest
+      .spyOn(instance, "requestGoals")
+      .mockResolvedValue(goalAnswer([]));
+
+    const noMarkerDoc = makeDocument(
+      ["before", "", ":::input", "  proof a", ":::", ""].join("\n"),
+    );
+
+    expect(
+      await call(instance, [], INPUT_AREA, LOWER_BOUND, noMarkerDoc),
+    ).toBe(InputAreaStatus.Incorrect);
+    expect(requestGoals).not.toHaveBeenCalled();
+  });
+
+  it("recognizes QED as a closing marker (Verbose Lean) and returns Correct when goals are empty", async () => {
+    const instance = makeClient();
+    jest.spyOn(instance, "requestGoals").mockResolvedValue(goalAnswer([]));
+
+    const qedDoc = makeDocument(
+      [
+        "before",
+        "",
+        ":::input",
+        "  proof a",
+        ":::",
+        "```lean",
+        "QED",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    expect(await call(instance, [], INPUT_AREA, LOWER_BOUND, qedDoc)).toBe(
+      InputAreaStatus.Correct,
+    );
+  });
+
+  it("uses the nearest marker and stays Incorrect for an unclosed proof followed by a later proof's marker", async () => {
+    const instance = makeClient();
+    jest
+      .spyOn(instance, "requestGoals")
+      .mockResolvedValue(goalAnswer(["⊢ False"]));
+
+    // First input area (lines 2..6) has no marker before the next :::input; the QED below
+    // belongs to the *second* proof and must not be borrowed to mark the first one complete.
+    const twoProofsDoc = makeDocument(
+      [
+        "before", // 0
+        "", // 1
+        ":::input", // 2  first area start
+        "  proof a", // 3
+        ":::", // 4  first area end (use a 5-line area for this doc)
+        "between", // 5
+        ":::input", // 6  second area start
+        "  proof b", // 7
+        ":::", // 8
+        "```lean", // 9
+        "QED", // 10
+        "```", // 11
+        "", // 12
+      ].join("\n"),
+    );
+
+    const firstArea = new Range(new Position(2, 0), new Position(4, 0));
+    expect(
+      await call(instance, [], firstArea, new Position(2, 0), twoProofsDoc),
+    ).toBe(InputAreaStatus.Incorrect);
   });
 
   // ---- sorry detection (Invalid) -----------------------------------------

--- a/completions/tacticsYalep.json
+++ b/completions/tacticsYalep.json
@@ -1,0 +1,47 @@
+[
+    {
+        "label": "let (*name*) be (*description*)",
+        "type": "type",
+        "detail": "tactic",
+        "template": "let ${n} be ${an integer}${}",
+        "description": "Introducing a variable",
+        "example": "let n be an integer",
+        "boost": 2
+    },
+    {
+        "label": "there exists (*description*) such that (*condition*)",
+        "type": "type",
+        "detail": "tactic",
+        "template": "there exists ${an integer p} such that ${p = p}${}",
+        "description": "There exists statement",
+        "example": "there exists an integer p such that p = p",
+        "boost": 2
+    },
+    {
+        "label": "for all (*domain*), (*condition*)",
+        "type": "type",
+        "detail": "tactic",
+        "template": "for all ${integers z}, ${z = z}${}",
+        "description": "For all statement",
+        "example": "for all integers z, z = z",
+        "boost": 2
+    },
+    {
+        "label": "assume (*condition*)",
+        "type": "type",
+        "detail": "tactic",
+        "template": "assume ${1 > 0}${}",
+        "description": "Assuming a condition",
+        "example": "assume 1 > 0",
+        "boost": 2
+    },
+    {
+        "label": "obtain such (*variable*)",
+        "type": "type",
+        "detail": "tactic",
+        "template": "obtain such ${p}${}",
+        "description": "Obtaining a variable ",
+        "example": "assume 1 > 0",
+        "boost": 2
+    } 
+]

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -10,6 +10,7 @@ import {
 // TODO: The tactics completions are static, we want them to be dynamic (LSP supplied and/or configurable when the editor is running)
 import waterproofTactics from "../../completions/tactics.json";
 import leanTactics from "../../completions/tacticsLean.json";
+import yalepTactics from "../../completions/tacticsYalep.json";
 import rocqTactics from "../../completions/tacticsRocq.json";
 import symbols from "../../completions/symbols+lean.json";
 
@@ -87,6 +88,9 @@ function createConfiguration(
         },
       };
       break;
+    // Yalep files share the Lean configuration, only the tactics completions
+    // differ (overridden after this switch).
+    case FileFormat.Yalep:
     case FileFormat.Lean:
       formatConf = {
         completions: leanTactics,
@@ -119,6 +123,11 @@ function createConfiguration(
         ],
       };
       break;
+  }
+
+  // Yalep files use the Lean configuration but with Yalep-specific tactics.
+  if (format === FileFormat.Yalep) {
+    formatConf.completions = yalepTactics;
   }
 
   // Create the WaterproofEditorConfig object

--- a/editor/src/messageHandler.ts
+++ b/editor/src/messageHandler.ts
@@ -38,9 +38,6 @@ export function handleEditorMessage(
       break;
     case MessageType.qedStatus: {
       const statuses = msg.body; // one status for each input area, in order
-      console.log(
-        `[WEBVIEW] qedStatus received, applying input area statuses: ${JSON.stringify(statuses)}`,
-      );
       editor.setInputAreaStatus(statuses);
       break;
     }

--- a/editor/src/messageHandler.ts
+++ b/editor/src/messageHandler.ts
@@ -38,6 +38,9 @@ export function handleEditorMessage(
       break;
     case MessageType.qedStatus: {
       const statuses = msg.body; // one status for each input area, in order
+      console.log(
+        `[WEBVIEW] qedStatus received, applying input area statuses: ${JSON.stringify(statuses)}`,
+      );
       editor.setInputAreaStatus(statuses);
       break;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@impermeable/codemirror-lang-rocq": "github:impermeable/codemirror-lang-rocq",
         "@impermeable/codemirror-lang-verbose": "github:impermeable/codemirror-lang-verbose",
         "@impermeable/codemirror-lang-waterproof": "github:impermeable/codemirror-lang-waterproof",
-        "@impermeable/waterproof-editor": "^0.14.0",
+        "@impermeable/waterproof-editor": "^0.15.1",
         "@leanprover/infoview": "^0.10.0",
         "@leanprover/infoview-api": "^0.10.0",
         "@ocaml-wasm/4.12--janestreet-base": "^0.16.0-0",
@@ -1858,9 +1858,9 @@
       }
     },
     "node_modules/@impermeable/waterproof-editor": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@impermeable/waterproof-editor/-/waterproof-editor-0.14.1.tgz",
-      "integrity": "sha512-hdnygUhSQO7Nliy7CVNtwH94spyDctzAi1N3zbufURz3m8rIEvKA0CTN4e1S6bFsJuMBBQRJYjrtNLUqMhTVUw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@impermeable/waterproof-editor/-/waterproof-editor-0.15.1.tgz",
+      "integrity": "sha512-IVISr5GiF+zCtXd5gYUall3pKy+bi1kAzz325uRR44OcmIP2yJbFTt/jTugrDiN+IFpMwB/GXJVpTI2GPMMW3w==",
       "license": "MIT",
       "dependencies": {
         "@benrbray/prosemirror-math": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -542,7 +542,7 @@
     "@impermeable/codemirror-lang-rocq": "github:impermeable/codemirror-lang-rocq",
     "@impermeable/codemirror-lang-verbose": "github:impermeable/codemirror-lang-verbose",
     "@impermeable/codemirror-lang-waterproof": "github:impermeable/codemirror-lang-waterproof",
-    "@impermeable/waterproof-editor": "^0.14.0",
+    "@impermeable/waterproof-editor": "^0.15.1",
     "@leanprover/infoview": "^0.10.0",
     "@leanprover/infoview-api": "^0.10.0",
     "@ocaml-wasm/4.12--janestreet-base": "^0.16.0-0",

--- a/shared/FileFormat.ts
+++ b/shared/FileFormat.ts
@@ -2,4 +2,5 @@ export const enum FileFormat {
   MarkdownV = "markdownv",
   RegularV = "regularv",
   Lean = "lean",
+  Yalep = "yalep",
 }

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -275,7 +275,16 @@ export abstract class LspClient<
   protected async onCheckingCompleted(): Promise<void> {
     // ensure there is an active document
     const document = this.activeDocument;
-    if (!document) return;
+    if (!document) {
+      wpl.debug(
+        `[onCheckingCompleted] 'document fully checked' received but no active document`,
+      );
+      return;
+    }
+    wpl.debug(
+      `[onCheckingCompleted] 'document fully checked' for ` +
+        `${document.uri.toString().split("/").pop()}; recomputing input area status`,
+    );
 
     // send message to ProseMirror editor that checking is done
     // (in addition to LSP message that indicates last Markdown is still being processed)
@@ -311,10 +320,21 @@ export abstract class LspClient<
       // get input areas based on tags
       const inputAreas = this.getInputAreas(document);
       if (!inputAreas) {
+        wpl.debug(
+          `[computeInputAreaStatus] getInputAreas returned undefined for ` +
+            `${document.uri.toString()} -> illegal input areas`,
+        );
         throw new Error("Cannot check proof status; illegal input areas.");
       }
 
       const diags = languages.getDiagnostics(document.uri);
+
+      wpl.debug(
+        `[computeInputAreaStatus] doc=${document.uri.toString().split("/").pop()}, ` +
+          `inputAreas=${inputAreas.length}, diagnostics=${diags.length}, ` +
+          `viewPortBasedChecking=${this.viewPortBasedChecking}, ` +
+          `viewPortRange=${this.viewPortRange ? JSON.stringify({ start: { line: this.viewPortRange.start.line, ch: this.viewPortRange.start.character }, end: { line: this.viewPortRange.end.line, ch: this.viewPortRange.end.character } }) : "undefined"}`,
+      );
 
       // for each input area, check the proof status
       try {
@@ -335,6 +355,12 @@ export abstract class LspClient<
 
             return this.determineProofStatus(document, area, diags, lowerBound);
           }),
+        );
+
+        wpl.debug(
+          `[computeInputAreaStatus] computed statuses for ` +
+            `doc=${document.uri.toString().split("/").pop()}: ${JSON.stringify(statuses)} ` +
+            `(sending qedStatus message to editor)`,
         );
 
         // forward statuses to corresponding ProseMirror editor

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -454,7 +454,11 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     let bestLength = 0;
     for (const marker of markers) {
       const idx = content.indexOf(marker, fromOffset);
-      if (idx >= 0 && idx < searchLimit && (bestStart === undefined || idx < bestStart)) {
+      if (
+        idx >= 0 &&
+        idx < searchLimit &&
+        (bestStart === undefined || idx < bestStart)
+      ) {
         bestStart = idx;
         bestLength = marker.length;
       }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -177,6 +177,12 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         (p) => p.kind === undefined || p.kind === FileProgressKind.Processing,
       );
       if (firstProcessing && this.webviewManager) {
+        if (!this.isBusy) {
+          wpl.debug(
+            `[leanClient.onFileProgress] isBusy false -> true (processing range starting at ` +
+              `line ${firstProcessing.range.start.line})`,
+          );
+        }
         this.isBusy = true;
         const { line, character } = firstProcessing.range.start;
         const from = this.activeDocument.offsetAt(
@@ -195,8 +201,18 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
           body: { from, to },
         });
       } else {
+        if (this.isBusy) {
+          wpl.debug(
+            `[leanClient.onFileProgress] isBusy true -> false (no processing ranges remain)`,
+          );
+        }
         this.isBusy = false;
       }
+      wpl.debug(
+        `[leanClient.onFileProgress] progress for active doc; ` +
+          `processingRanges=${progress.processing.length}, isBusy=${this.isBusy}; ` +
+          `recomputing input area status`,
+      );
       this.computeInputAreaStatus(this.activeDocument);
     }
   }
@@ -271,13 +287,26 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     // find (positions of) opening and closings tags for input areas, and check that they're valid
     const openOffsets = findOccurrences(":::input\n", content);
 
-    return openOffsets.map((openPos) => {
+    const inputAreas = openOffsets.map((openPos) => {
       const closePos = content.indexOf(":::\n", openPos);
       return new Range(
         document.positionAt(openPos),
         document.positionAt(closePos),
       );
     });
+
+    wpl.debug(
+      `[leanClient.getInputAreas] doc=${document.uri.toString().split("/").pop()}, ` +
+        `':::input\\n' openOffsets=${JSON.stringify(openOffsets)}, ` +
+        `found ${inputAreas.length} input area(s): ${JSON.stringify(
+          inputAreas.map((a) => ({
+            start: { line: a.start.line, ch: a.start.character },
+            end: { line: a.end.line, ch: a.end.character },
+          })),
+        )}`,
+    );
+
+    return inputAreas;
   }
 
   protected async determineProofStatus(
@@ -286,11 +315,22 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     diags: Array<Diagnostic>,
     lowerBound: Position,
   ): Promise<InputAreaStatus> {
+    wpl.debug(
+      `[leanClient.determineProofStatus] called for inputArea ` +
+        `start=(${inputArea.start.line},${inputArea.start.character}) ` +
+        `end=(${inputArea.end.line},${inputArea.end.character}), ` +
+        `lowerBound=(${lowerBound.line},${lowerBound.character}), ` +
+        `isBusy=${this.isBusy}, totalDiags=${diags.length}`,
+    );
+
     // If Lean hasn't finished processing up to the end of this input area, an empty goals
     // response simply means "not checked yet" rather than "proof complete".  Guard against
     // that to prevent the bar from turning green prematurely (e.g. while typing "We ap" or
     // when the proof has invalid syntax like "Help\n• Fix a : ℝ\n" without a closing Qed).
     if (this.isBusy) {
+      wpl.debug(
+        `[leanClient.determineProofStatus] -> Incorrect (server still busy, status undetermined)`,
+      );
       return InputAreaStatus.Incorrect;
     }
 
@@ -306,25 +346,68 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
     const hasErrorDiagnostic = diagsInArea.some(
       (d) => d.severity === DiagnosticSeverity.Error,
     );
+    wpl.debug(
+      `[leanClient.determineProofStatus] diagsInArea=${diagsInArea.length}, ` +
+        `hasErrorDiagnostic=${hasErrorDiagnostic}, ` +
+        `diagsInArea=${JSON.stringify(
+          diagsInArea.map((d) => ({
+            severity: d.severity,
+            range: {
+              start: { line: d.range.start.line, ch: d.range.start.character },
+              end: { line: d.range.end.line, ch: d.range.end.character },
+            },
+            msg: d.message?.substring(0, 60),
+          })),
+        )}`,
+    );
     if (hasErrorDiagnostic) {
+      wpl.debug(
+        `[leanClient.determineProofStatus] -> Incorrect (error-level diagnostic inside input area)`,
+      );
       return InputAreaStatus.Incorrect;
     }
 
-    // Request goals
-    const goalsPosition = inputArea.end.translate(0, 0);
+    // The proof's closing marker (`□` in Yalep, `QED` in Verbose Lean) lives in a `lean`
+    // block *after* the input area's closing `:::`. In these dialects the marker is an active
+    // step that discharges the final goal, so proof completion must be measured at the marker
+    // rather than at `inputArea.end` (which would still show an open goal for a finished
+    // proof). This mirrors the Rocq client, which queries goals at the `Qed.` after the input
+    // area. If no marker is present, the proof isn't closed and the area is incorrect.
+    const markerPosition = this.findProofEndPosition(document, inputArea.end);
+    if (!markerPosition) {
+      wpl.debug(
+        `[leanClient.determineProofStatus] -> Incorrect (no closing marker '□'/'QED' after input area)`,
+      );
+      return InputAreaStatus.Incorrect;
+    }
 
     const goalsParams = this.createGoalsRequestParameters(
       document,
-      goalsPosition,
+      markerPosition,
     );
     const response = await this.requestGoals(goalsParams);
 
+    wpl.debug(
+      `[leanClient.determineProofStatus] goals requested at marker position ` +
+        `(${markerPosition.line},${markerPosition.character}), ` +
+        `response=${response ? `present, goals.length=${response.goals.length}` : "null"}, ` +
+        `goals=${response ? JSON.stringify(response.goals) : "n/a"}`,
+    );
+
     if (!response) {
+      wpl.debug(
+        `[leanClient.determineProofStatus] -> Incorrect (no goals response)`,
+      );
       return InputAreaStatus.Incorrect;
     }
 
     // return incorrect if there are still goals remaining
-    if (response.goals.length > 0) return InputAreaStatus.Incorrect;
+    if (response.goals.length > 0) {
+      wpl.debug(
+        `[leanClient.determineProofStatus] -> Incorrect (${response.goals.length} goal(s) remaining)`,
+      );
+      return InputAreaStatus.Incorrect;
+    }
 
     // Goals are empty, proof looks complete, but check for sorry
     // The Lean LSP prefixes all sorry-like aliases with "declaration uses " including hint
@@ -339,7 +422,47 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
         d.range.start.isBeforeOrEqual(inputArea.end) &&
         d.message.startsWith(SORRY_PREFIX),
     );
-    return hasSorry ? InputAreaStatus.Invalid : InputAreaStatus.Correct;
+    const status = hasSorry ? InputAreaStatus.Invalid : InputAreaStatus.Correct;
+    wpl.debug(
+      `[leanClient.determineProofStatus] no goals remaining; hasSorry=${hasSorry} -> ${status}`,
+    );
+    return status;
+  }
+
+  /**
+   * Finds the position just after the proof-closing marker (`□` in Yalep, `QED` in Verbose
+   * Lean) that follows `searchFrom` in the document. In these dialects the marker lives in a
+   * `lean` block *after* the input area's closing `:::`, and it is the step that discharges
+   * the final goal — so proof completion must be measured here rather than at the input-area
+   * boundary. Returns the earliest marker's end position, or `undefined` when no marker is
+   * present (i.e. the proof isn't closed yet).
+   */
+  private findProofEndPosition(
+    document: TextDocument,
+    searchFrom: Position,
+  ): Position | undefined {
+    const content = document.getText();
+    const fromOffset = document.offsetAt(searchFrom);
+
+    // Bound the search to before the next input area, so an unclosed proof can't borrow the
+    // closing marker of a later proof (which would falsely mark this area complete).
+    const nextInputArea = content.indexOf(":::input\n", fromOffset);
+    const searchLimit = nextInputArea >= 0 ? nextInputArea : content.length;
+
+    const markers = ["□", "QED"];
+    let bestStart: number | undefined;
+    let bestLength = 0;
+    for (const marker of markers) {
+      const idx = content.indexOf(marker, fromOffset);
+      if (idx >= 0 && idx < searchLimit && (bestStart === undefined || idx < bestStart)) {
+        bestStart = idx;
+        bestLength = marker.length;
+      }
+    }
+
+    return bestStart === undefined
+      ? undefined
+      : document.positionAt(bestStart + bestLength);
   }
 
   // Emitters for infoview

--- a/src/pm-editor/fileUtils.ts
+++ b/src/pm-editor/fileUtils.ts
@@ -17,6 +17,10 @@ export function getFormatFromExtension(
   } else if (extension === "v") {
     return FileFormat.RegularV;
   } else if (extension === "lean") {
+    // Yalep files are Lean files that end in `_yalep.lean`.
+    if (doc.uri.fsPath.endsWith("_yalep.lean")) {
+      return FileFormat.Yalep;
+    }
     return FileFormat.Lean;
   }
 

--- a/src/webviews/standardviews/tactics.ts
+++ b/src/webviews/standardviews/tactics.ts
@@ -9,6 +9,8 @@ import {
 import dataRocq from "../../../completions/tactics.json";
 // Import the JSON data for Lean tactics
 import dataLean from "../../../completions/tacticsLean.json";
+// Import the JSON data for Yalep tactics (Lean files ending in `_yalep.lean`)
+import dataYalep from "../../../completions/tacticsYalep.json";
 import { CompositeClient } from "../../lsp-client/composite";
 import { RocqLspClient } from "../../lsp-client/rocq";
 import { LeanLspClient } from "../../lsp-client/lean";
@@ -16,6 +18,7 @@ import type { TacticsData } from "../../../shared";
 
 export class TacticsPanel extends WaterproofPanel {
   private lastClient?: RocqLspClient | LeanLspClient;
+  private isYalep = false;
 
   constructor(extensionUri: Uri) {
     // Initialize the tactics panel with the extension Uri and the webview name
@@ -48,14 +51,20 @@ export class TacticsPanel extends WaterproofPanel {
   showView(_name: string, data?: TacticsData) {
     if (data) super.showView("tactics", data);
     else if (this.lastClient instanceof LeanLspClient)
-      super.showView("tactics", dataLean);
+      super.showView("tactics", this.isYalep ? dataYalep : dataLean);
     else super.showView("tactics", dataRocq);
   }
 
   update(client: CompositeClient) {
-    if (!client || this.lastClient === client.activeClient) return;
+    if (!client) return;
+
+    const isYalep =
+      client.activeDocument?.uri.fsPath.endsWith("_yalep.lean") ?? false;
+    if (this.lastClient === client.activeClient && this.isYalep === isYalep)
+      return;
 
     this.lastClient = client.activeClient;
+    this.isYalep = isYalep;
     this.showView("tactics");
   }
 }


### PR DESCRIPTION
Turns on when a file ends with _yalep.lean.

Uses highlighting from Lean, so that might be broken.

