### PR TITLE
Removed the "starting at line x" message in the subproof incomplete message

### DIFF
--- a/__tests__/lsp-client/lean/client.test.ts
+++ b/__tests__/lsp-client/lean/client.test.ts
@@ -844,9 +844,7 @@ describe("LeanLspClient.rewriteDiagnostics", () => {
 
     const result = rewrite(instance, [unsolvedDiag(3, 5)], [AREA]);
 
-    expect(result[0].message).toBe(
-      "(Sub)proof is not finished yet.",
-    );
+    expect(result[0].message).toBe("(Sub)proof is not finished yet.");
   });
 
   it("leaves the message unchanged when the UnsolvedGoals diagnostic is outside all input areas", () => {

--- a/__tests__/lsp-client/lean/client.test.ts
+++ b/__tests__/lsp-client/lean/client.test.ts
@@ -845,7 +845,7 @@ describe("LeanLspClient.rewriteDiagnostics", () => {
     const result = rewrite(instance, [unsolvedDiag(3, 5)], [AREA]);
 
     expect(result[0].message).toBe(
-      "(Sub)proof starting on line 4 is not finished yet.",
+      "(Sub)proof is not finished yet.",
     );
   });
 

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -124,7 +124,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
           // rewrite unsolved goals messages inside input areas to be more user-friendly
           return {
             ...d,
-            message: `(Sub)proof starting on line ${d.range.start.line + 1} is not finished yet.`,
+            message: `(Sub)proof is not finished yet.`,
           };
         }
       }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -124,7 +124,9 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
           // rewrite unsolved goals messages inside input areas to be more user-friendly
           return {
             ...d,
-            message: `(Sub)proof is not finished yet.`,
+            // NOTE: If we have line numbers again, we may want to include them in the message, e.g.:
+            // `(Sub)proof starting on line ${d.range.start.line + 1} is not finished yet.`
+            message: "(Sub)proof is not finished yet.",
           };
         }
       }

--- a/src/lsp-client/lean/client.ts
+++ b/src/lsp-client/lean/client.ts
@@ -125,7 +125,7 @@ export class LeanLspClient extends LspClient<LeanGoalRequest, LeanGoalAnswer> {
           return {
             ...d,
             // NOTE: If we have line numbers again, we may want to include them in the message, e.g.:
-            // `(Sub)proof starting on line ${d.range.start.line + 1} is not finished yet.`
+            // `(Sub)proof on line ${d.range.start.line + 1} is not finished yet.`
             message: "(Sub)proof is not finished yet.",
           };
         }


### PR DESCRIPTION
Since we no longer have line numbers, saying "(Sub)proof at line x is not finished yet" does not really make sense anymore.

This file changes the diagnostic to not include the message about the line number. It also fixes the test that checked for the presence of this line number.

I initially thought that we could set the message dynamically based on whether line numbers are disabled or not, but if we decide to have line numbers again, but using some kind of "correction function" to adjust the line numbers in the gutter, you would need to modify the message anyway to use that new adjustment function. That is why instead I just left a comment if we ever decide to add it back in the future.

