### PR TITLE
Add template configurations

### DIFF
--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -67,8 +67,9 @@ function createConfiguration(
         toMarkdown: defaultToMarkdown,
         markdownName: "Markdown",
         templates: {
-          example: 'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
-          exercise: ""
+          example:
+            'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
+          exercise: "",
         },
         tagConfiguration: markdown.configuration("coq"),
         languageConfig: {
@@ -86,7 +87,7 @@ function createConfiguration(
         markdownName: "Rocq doc",
         templates: {
           example: "",
-          exercise: ""
+          exercise: "",
         },
         tagConfiguration: tagConfigurationV,
         disableMarkdownFeatures: ["code"],
@@ -107,8 +108,9 @@ function createConfiguration(
         toMarkdown: versoMarkdownToMarkdown,
         markdownName: "Markdown",
         templates: {
-          example: 'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
-          exercise: ""
+          example:
+            'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
+          exercise: "",
         },
         tagConfiguration: tagConfigurationLean,
         serializer: new LeanSerializer(),

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -68,7 +68,7 @@ function createConfiguration(
         markdownName: "Markdown",
         templates: {
           example: "Example example: True.\nProof.\n\nQed.",
-          exercise: { statement: "Lemma exercise:", proof: "Qed." },
+          exercise: { statement: "Lemma exercise:\nProof.", proof: "Qed." },
           containerOpenTag: "",
         },
         tagConfiguration: markdown.configuration("coq"),
@@ -113,7 +113,7 @@ function createConfiguration(
             'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
           exercise: {
             statement:
-              'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:',
+              'Exercise "exercise"\nGiven:\nAssume:\nConclusion:\nProof:',
             proof: "QED",
           },
           containerOpenTag: "multilean",

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -53,7 +53,7 @@ function createConfiguration(
     | "languageConfig"
     | "disableMarkdownFeatures"
     | "serializer"
-    | "exampleTemplate"
+    | "templates"
     | "menubarEntries"
   >;
 
@@ -66,7 +66,10 @@ function createConfiguration(
           markdown.parse(v, { language: "coq" }),
         toMarkdown: defaultToMarkdown,
         markdownName: "Markdown",
-        exampleTemplate: "Example example: True.\nProof.\n\nQed.",
+        templates: {
+          example: 'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
+          exercise: ""
+        },
         tagConfiguration: markdown.configuration("coq"),
         languageConfig: {
           highlightDark: langWp.highlight_dark,
@@ -81,7 +84,10 @@ function createConfiguration(
         documentConstructor: vFileParser,
         toMarkdown: rocqdocToMarkdown,
         markdownName: "Rocq doc",
-        exampleTemplate: "",
+        templates: {
+          example: "",
+          exercise: ""
+        },
         tagConfiguration: tagConfigurationV,
         disableMarkdownFeatures: ["code"],
         languageConfig: {
@@ -100,7 +106,10 @@ function createConfiguration(
         documentConstructor: topLevelBlocksLean,
         toMarkdown: versoMarkdownToMarkdown,
         markdownName: "Markdown",
-        exampleTemplate: 'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
+        templates: {
+          example: 'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
+          exercise: ""
+        },
         tagConfiguration: tagConfigurationLean,
         serializer: new LeanSerializer(),
         languageConfig: {

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -53,6 +53,7 @@ function createConfiguration(
     | "languageConfig"
     | "disableMarkdownFeatures"
     | "serializer"
+    | "exampleTemplate"
     | "menubarEntries"
   >;
 
@@ -65,6 +66,7 @@ function createConfiguration(
           markdown.parse(v, { language: "coq" }),
         toMarkdown: defaultToMarkdown,
         markdownName: "Markdown",
+        exampleTemplate: "Example example: True.\nProof.\n\nQed.",
         tagConfiguration: markdown.configuration("coq"),
         languageConfig: {
           highlightDark: langWp.highlight_dark,
@@ -79,6 +81,7 @@ function createConfiguration(
         documentConstructor: vFileParser,
         toMarkdown: rocqdocToMarkdown,
         markdownName: "Rocq doc",
+        exampleTemplate: "",
         tagConfiguration: tagConfigurationV,
         disableMarkdownFeatures: ["code"],
         languageConfig: {
@@ -97,6 +100,7 @@ function createConfiguration(
         documentConstructor: topLevelBlocksLean,
         toMarkdown: versoMarkdownToMarkdown,
         markdownName: "Markdown",
+        exampleTemplate: 'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
         tagConfiguration: tagConfigurationLean,
         serializer: new LeanSerializer(),
         languageConfig: {

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -67,9 +67,9 @@ function createConfiguration(
         toMarkdown: defaultToMarkdown,
         markdownName: "Markdown",
         templates: {
-          example:
-            'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
-          exercise: "",
+          example: "Example example: True.\nProof.\n\nQed.",
+          exercise: { statement: "Lemma exercise:", proof: "Qed." },
+          containerOpenTag: "",
         },
         tagConfiguration: markdown.configuration("coq"),
         languageConfig: {
@@ -87,7 +87,8 @@ function createConfiguration(
         markdownName: "Rocq doc",
         templates: {
           example: "",
-          exercise: "",
+          exercise: { statement: "", proof: "" },
+          containerOpenTag: "",
         },
         tagConfiguration: tagConfigurationV,
         disableMarkdownFeatures: ["code"],
@@ -110,7 +111,12 @@ function createConfiguration(
         templates: {
           example:
             'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:\n\nQED',
-          exercise: "",
+          exercise: {
+            statement:
+              'Example "example"\nGiven:\nAssume:\nConclusion:\nProof:',
+            proof: "QED",
+          },
+          containerOpenTag: "multilean",
         },
         tagConfiguration: tagConfigurationLean,
         serializer: new LeanSerializer(),


### PR DESCRIPTION
### Description
Accompanying PR to https://github.com/impermeable/waterproof-editor/pull/103, allowing us to abstract to insertion templates rather than hardcoding.

### Changes
Adds TemplateConfiguration type to the WaterproofEditorConfigs.

### Testing this PR
Link this waterproof editor branch to the additional_menubar_buttons branch in waterproof-editor. Run the tests in insert-commands.test.ts and try out the buttons in the waterproof_tutorial file. 

NOTE: The typecheck failing is expected as main does not yet have the "templates" value.