### PR TITLE
Add pos argument to tryStep and return proofRange via proofContext

### DIFF
--- a/__tests__/extension/proofContext.test.ts
+++ b/__tests__/extension/proofContext.test.ts
@@ -169,11 +169,7 @@ type Ctx = {
   };
 };
 
-function makeCtx(
-  document: unknown,
-  cursor: unknown,
-  symbols: Sym[],
-): Ctx {
+function makeCtx(document: unknown, cursor: unknown, symbols: Sym[]): Ctx {
   return {
     client: {
       activeDocument: document,
@@ -258,8 +254,7 @@ describe("Waterproof.proofContext", () => {
       const result = await proofContext.call(ctx);
 
       const barIdx = SOURCE.indexOf("Lemma bar");
-      const expectedStart =
-        SOURCE.indexOf("Proof.", barIdx) + "Proof.".length;
+      const expectedStart = SOURCE.indexOf("Proof.", barIdx) + "Proof.".length;
       const expectedEnd = SOURCE.indexOf("Qed.", barIdx);
 
       expect(result.proofRange.start).toEqual(doc.positionAt(expectedStart));
@@ -342,9 +337,13 @@ describe("Waterproof.proofContext", () => {
     it("throws when the lemma keyword is not recognised", async () => {
       // `Example` is not in the accepted keyword list, so the start regex
       // fails even though a closer is present.
-      const text = ["Example ex : True.", "Proof.", "exact I.", "Qed.", ""].join(
-        "\n",
-      );
+      const text = [
+        "Example ex : True.",
+        "Proof.",
+        "exact I.",
+        "Qed.",
+        "",
+      ].join("\n");
       const doc = makeDocument(text);
       const ctx = makeCtx(doc, new Position(2, 0), [
         { name: "ex", range: { start: { line: 0, character: 0 } } },

--- a/__tests__/extension/proofContext.test.ts
+++ b/__tests__/extension/proofContext.test.ts
@@ -355,14 +355,12 @@ describe("Waterproof.proofContext", () => {
     });
   });
 
-  describe("known breakage: statement contains an internal period", () => {
-    // The start regex consumes the statement body with `[^.]*`, which stops at
-    // the FIRST period. A statement containing an internal period -- e.g. a
-    // qualified name like `Nat.add` -- therefore fails to match, even though it
-    // is a perfectly valid lemma. This test documents that limitation; see the
-    // NOTE on `startRegex` in src/extension.ts. It is expected to fail (throw)
-    // and would need to change if the regex is ever fixed.
-    it("throws on a valid lemma whose statement uses a qualified name", async () => {
+  describe("statement contains an internal period", () => {
+    // Regression test for the `[\s\S]*?` fix to `startRegex`: a statement with
+    // an internal period (e.g. a qualified name) must still be handled, since
+    // the sentence terminator is a period *followed by whitespace*, not the
+    // first period in the statement.
+    it("extracts a lemma whose statement uses a qualified name", async () => {
       const text = [
         "Lemma bar : Nat.add 0 0 = 0.",
         "Proof.",
@@ -375,9 +373,21 @@ describe("Waterproof.proofContext", () => {
         { name: "bar", range: { start: { line: 0, character: 0 } } },
       ]);
 
-      await expect(proofContext.call(ctx)).rejects.toThrow(
-        "Could not find start of proof",
+      const result = await proofContext.call(ctx);
+
+      expect(result.name).toBe("bar");
+      expect(result.full).toBe(
+        "Lemma bar : Nat.add 0 0 = 0. Proof. reflexivity. Qed. ",
       );
+      // The marker lands at the start of the proof body, after `Proof.`.
+      expect(result.withCursorMarker).toBe(
+        "Lemma bar : Nat.add 0 0 = 0. Proof. {!* CURSOR *!}reflexivity. Qed. ",
+      );
+
+      const expectedStart = text.indexOf("Proof.") + "Proof.".length;
+      const expectedEnd = text.indexOf("Qed.");
+      expect(result.proofRange.start).toEqual(doc.positionAt(expectedStart));
+      expect(result.proofRange.end).toEqual(doc.positionAt(expectedEnd));
     });
   });
 });

--- a/__tests__/extension/proofContext.test.ts
+++ b/__tests__/extension/proofContext.test.ts
@@ -354,4 +354,30 @@ describe("Waterproof.proofContext", () => {
       );
     });
   });
+
+  describe("known breakage: statement contains an internal period", () => {
+    // The start regex consumes the statement body with `[^.]*`, which stops at
+    // the FIRST period. A statement containing an internal period -- e.g. a
+    // qualified name like `Nat.add` -- therefore fails to match, even though it
+    // is a perfectly valid lemma. This test documents that limitation; see the
+    // NOTE on `startRegex` in src/extension.ts. It is expected to fail (throw)
+    // and would need to change if the regex is ever fixed.
+    it("throws on a valid lemma whose statement uses a qualified name", async () => {
+      const text = [
+        "Lemma bar : Nat.add 0 0 = 0.",
+        "Proof.",
+        "reflexivity.",
+        "Qed.",
+        "",
+      ].join("\n");
+      const doc = makeDocument(text);
+      const ctx = makeCtx(doc, new Position(2, 0), [
+        { name: "bar", range: { start: { line: 0, character: 0 } } },
+      ]);
+
+      await expect(proofContext.call(ctx)).rejects.toThrow(
+        "Could not find start of proof",
+      );
+    });
+  });
 });

--- a/__tests__/extension/proofContext.test.ts
+++ b/__tests__/extension/proofContext.test.ts
@@ -1,0 +1,357 @@
+// Unit tests for the `proofContext` method on the Waterproof extension class.
+//
+// LLM-generated tests that might encode existing faulty behaviour.
+//
+// `proofContext` is a plain prototype method, so we exercise it in isolation by
+// invoking it with a hand-rolled `this` context (`Waterproof.prototype
+// .proofContext.call(fakeThis, ...)`) instead of constructing the full
+// extension, which would pull in the entire VS Code activation path.
+//
+// The document is modelled from a real source string so that
+// getText/offsetAt/positionAt stay mutually consistent and the tests exercise
+// the actual regex + offset arithmetic.
+
+jest.mock(
+  "vscode",
+  () => ({
+    Position: class {
+      constructor(
+        public line: number,
+        public character: number,
+      ) {}
+      isBefore(other: { line: number; character: number }) {
+        return (
+          this.line < other.line ||
+          (this.line === other.line && this.character < other.character)
+        );
+      }
+    },
+    Range: class {
+      constructor(
+        public start: unknown,
+        public end: unknown,
+      ) {}
+    },
+    commands: {
+      registerCommand: jest.fn(),
+      registerTextEditorCommand: jest.fn(),
+      executeCommand: jest.fn(),
+    },
+    window: {
+      createOutputChannel: jest.fn(() => ({
+        appendLine: jest.fn(),
+        dispose: jest.fn(),
+      })),
+    },
+    workspace: {},
+    ConfigurationTarget: { Global: 1 },
+    Uri: { parse: jest.fn(), joinPath: jest.fn() },
+    RevealOutputChannelOn: { Info: 1 },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "vscode-languageclient",
+  () => ({
+    RevealOutputChannelOn: { Info: 1 },
+  }),
+  { virtual: true },
+);
+
+// extension.ts imports a large collaborator graph; everything below is mocked so
+// the module loads cheaply. Mirrors the setup in eventHandlers.test.ts.
+jest.mock("../../src/lsp-client/commandExecutor", () => ({
+  executeCommand: jest.fn(),
+  executeCommandFullOutput: jest.fn(),
+}));
+jest.mock("../../src/helpers", () => ({
+  WaterproofLogger: { log: jest.fn(), debug: jest.fn(), show: jest.fn() },
+  WaterproofConfigHelper: {
+    get: jest.fn(),
+    update: jest.fn(),
+    configuration: {},
+  },
+  WaterproofFileUtil: {},
+  WaterproofPackageJSON: {},
+  WaterproofSetting: {},
+}));
+jest.mock("../../src/pm-editor", () => ({
+  WaterproofEditorProvider: { register: jest.fn() },
+}));
+jest.mock("../../src/util", () => ({
+  checkConflictingExtensions: jest.fn(),
+  excludeRocqFileTypes: jest.fn(),
+  checkTrimmingWhitespace: jest.fn(),
+}));
+jest.mock("../../src/components/enableButton", () => ({
+  WaterproofStatusBar: class {},
+}));
+jest.mock("../../src/webviews/sidePanel", () => ({
+  addSidePanel: jest.fn(),
+  SidePanelProvider: class {},
+}));
+jest.mock("../../src/webviews/standardviews/search", () => ({
+  Search: class {},
+}));
+jest.mock("../../src/webviews/standardviews/execute", () => ({
+  ExecutePanel: class {},
+}));
+jest.mock("../../src/webviews/standardviews/symbols", () => ({
+  SymbolsPanel: class {},
+}));
+jest.mock("../../src/webviews/standardviews/tactics", () => ({
+  TacticsPanel: class {},
+}));
+jest.mock("../../src/webviews/goalviews/debug", () => ({
+  DebugPanel: class {},
+}));
+jest.mock("../../src/webviews/goalviews/goalsPanel", () => ({
+  GoalsPanel: class {},
+}));
+jest.mock("../../src/webviews/goalviews/compositeGoalsPanel", () => ({
+  CompositeGoalsPanel: class {},
+}));
+jest.mock("../../src/lsp-client/composite", () => ({
+  CompositeClient: class {},
+}));
+jest.mock("../../src/lsp-client/rocq", () => ({
+  RocqLspServerConfig: { create: jest.fn() },
+}));
+jest.mock("../../src/lsp-client/lean", () => ({
+  LeanLspServerConfig: { create: jest.fn() },
+}));
+jest.mock("../../src/helpers/exerciseSheet", () => ({
+  clearInputCells: jest.fn(),
+}));
+
+import { Position } from "vscode";
+import { Waterproof } from "../../src/extension";
+
+type Sym = {
+  name: string;
+  range: { start: { line: number; character: number } };
+};
+
+/**
+ * Minimal text-backed stand-in for a VS Code `TextDocument`. `\n` separates
+ * lines; offsetAt/positionAt are exact inverses for in-bounds positions.
+ */
+function makeDocument(text: string) {
+  const lineStarts = [0];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n") lineStarts.push(i + 1);
+  }
+  return {
+    uri: { toString: () => "file:///proof.v" },
+    version: 1,
+    getText: () => text,
+    offsetAt: (pos: { line: number; character: number }) => {
+      const base = lineStarts[pos.line] ?? text.length;
+      return base + pos.character;
+    },
+    positionAt: (offset: number) => {
+      let line = 0;
+      for (let i = 0; i < lineStarts.length; i++) {
+        if (lineStarts[i] <= offset) line = i;
+        else break;
+      }
+      return new Position(line, offset - lineStarts[line]);
+    },
+  };
+}
+
+type Ctx = {
+  client: {
+    activeDocument: unknown;
+    activeCursorPosition: unknown;
+    requestSymbols: jest.Mock;
+  };
+};
+
+function makeCtx(
+  document: unknown,
+  cursor: unknown,
+  symbols: Sym[],
+): Ctx {
+  return {
+    client: {
+      activeDocument: document,
+      activeCursorPosition: cursor,
+      requestSymbols: jest.fn(async () => symbols),
+    },
+  };
+}
+
+const proofContext = (
+  Waterproof.prototype as unknown as {
+    proofContext: (
+      this: unknown,
+      cursorMarker?: string,
+    ) => Promise<{
+      name: string;
+      full: string;
+      withCursorMarker: string;
+      proofRange: { start: unknown; end: unknown };
+    }>;
+  }
+).proofContext;
+
+// A document with two lemmas so we can test lemma selection as well as the
+// happy-path extraction.
+const SOURCE = [
+  "Lemma foo : True.", // line 0
+  "Proof.", // line 1
+  "exact I.", // line 2
+  "Qed.", // line 3
+  "", // line 4
+  "Lemma bar : 1 = 1.", // line 5
+  "Proof.", // line 6
+  "reflexivity.", // line 7
+  "Qed.", // line 8
+  "", // line 9 (trailing newline)
+].join("\n");
+
+const SYMBOLS: Sym[] = [
+  { name: "foo", range: { start: { line: 0, character: 0 } } },
+  { name: "bar", range: { start: { line: 5, character: 0 } } },
+];
+
+describe("Waterproof.proofContext", () => {
+  describe("happy path", () => {
+    it("extracts the lemma the cursor is inside, with whitespace collapsed", async () => {
+      const doc = makeDocument(SOURCE);
+      const ctx = makeCtx(doc, new Position(7, 0), SYMBOLS);
+
+      const result = await proofContext.call(ctx);
+
+      expect(result.name).toBe("bar");
+      expect(result.full).toBe("Lemma bar : 1 = 1. Proof. reflexivity. Qed. ");
+    });
+
+    it("inserts the default cursor marker at the cursor offset", async () => {
+      const doc = makeDocument(SOURCE);
+      const ctx = makeCtx(doc, new Position(7, 0), SYMBOLS);
+
+      const result = await proofContext.call(ctx);
+
+      expect(result.withCursorMarker).toBe(
+        "Lemma bar : 1 = 1. Proof. {!* CURSOR *!}reflexivity. Qed. ",
+      );
+    });
+
+    it("honours a custom cursor marker", async () => {
+      const doc = makeDocument(SOURCE);
+      const ctx = makeCtx(doc, new Position(7, 0), SYMBOLS);
+
+      const result = await proofContext.call(ctx, "<HERE>");
+
+      expect(result.withCursorMarker).toBe(
+        "Lemma bar : 1 = 1. Proof. <HERE>reflexivity. Qed. ",
+      );
+    });
+
+    it("returns a proofRange from the end of `Proof.` to the start of the closer", async () => {
+      const doc = makeDocument(SOURCE);
+      const ctx = makeCtx(doc, new Position(7, 0), SYMBOLS);
+
+      const result = await proofContext.call(ctx);
+
+      const barIdx = SOURCE.indexOf("Lemma bar");
+      const expectedStart =
+        SOURCE.indexOf("Proof.", barIdx) + "Proof.".length;
+      const expectedEnd = SOURCE.indexOf("Qed.", barIdx);
+
+      expect(result.proofRange.start).toEqual(doc.positionAt(expectedStart));
+      expect(result.proofRange.end).toEqual(doc.positionAt(expectedEnd));
+    });
+
+    it("selects the nearest lemma before the cursor when several exist", async () => {
+      const doc = makeDocument(SOURCE);
+      const ctx = makeCtx(doc, new Position(2, 0), SYMBOLS);
+
+      const result = await proofContext.call(ctx);
+
+      expect(result.name).toBe("foo");
+      expect(result.full).toBe("Lemma foo : True. Proof. exact I. Qed. ");
+    });
+  });
+
+  describe("marker / fence stripping", () => {
+    it("removes input-area tags and coq code fences", async () => {
+      const text = [
+        "Lemma baz : True.",
+        "Proof.",
+        "<input-area>",
+        "```coq",
+        "exact I.",
+        "```",
+        "</input-area>",
+        "Qed.",
+        "",
+      ].join("\n");
+      const doc = makeDocument(text);
+      const ctx = makeCtx(doc, new Position(4, 0), [
+        { name: "baz", range: { start: { line: 0, character: 0 } } },
+      ]);
+
+      const result = await proofContext.call(ctx);
+
+      expect(result.full).not.toMatch(/input-area/);
+      expect(result.full).not.toMatch(/```/);
+      expect(result.full).toBe("Lemma baz : True. Proof. exact I. Qed. ");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when there is no active document", async () => {
+      const ctx = makeCtx(undefined, new Position(7, 0), SYMBOLS);
+      await expect(proofContext.call(ctx)).rejects.toThrow(
+        "No active document or cursor position",
+      );
+    });
+
+    it("throws when there is no cursor position", async () => {
+      const doc = makeDocument(SOURCE);
+      const ctx = makeCtx(doc, undefined, SYMBOLS);
+      await expect(proofContext.call(ctx)).rejects.toThrow(
+        "No active document or cursor position",
+      );
+    });
+
+    it("throws when no lemma symbol precedes the cursor", async () => {
+      const doc = makeDocument(SOURCE);
+      // Cursor before every symbol.
+      const ctx = makeCtx(doc, new Position(0, 0), SYMBOLS);
+      await expect(proofContext.call(ctx)).rejects.toThrow(
+        "Could not find lemma before cursor",
+      );
+    });
+
+    it("throws when the proof has no Qed/Admitted/Defined closer", async () => {
+      const text = ["Lemma open : True.", "Proof.", "exact I.", ""].join("\n");
+      const doc = makeDocument(text);
+      const ctx = makeCtx(doc, new Position(2, 0), [
+        { name: "open", range: { start: { line: 0, character: 0 } } },
+      ]);
+      await expect(proofContext.call(ctx)).rejects.toThrow(
+        "Could not find end of proof",
+      );
+    });
+
+    it("throws when the lemma keyword is not recognised", async () => {
+      // `Example` is not in the accepted keyword list, so the start regex
+      // fails even though a closer is present.
+      const text = ["Example ex : True.", "Proof.", "exact I.", "Qed.", ""].join(
+        "\n",
+      );
+      const doc = makeDocument(text);
+      const ctx = makeCtx(doc, new Position(2, 0), [
+        { name: "ex", range: { start: { line: 0, character: 0 } } },
+      ]);
+      await expect(proofContext.call(ctx)).rejects.toThrow(
+        "Could not find start of proof",
+      );
+    });
+  });
+});

--- a/__tests__/extension/proofContext.test.ts
+++ b/__tests__/extension/proofContext.test.ts
@@ -334,11 +334,36 @@ describe("Waterproof.proofContext", () => {
       );
     });
 
-    it("throws when the lemma keyword is not recognised", async () => {
-      // `Example` is not in the accepted keyword list, so the start regex
-      // fails even though a closer is present.
+    it("recognises the `Example` keyword", async () => {
+      // `Example` is part of the accepted keyword list, so the start regex
+      // matches and the proof context is extracted successfully.
       const text = [
         "Example ex : True.",
+        "Proof.",
+        "exact I.",
+        "Qed.",
+        "",
+      ].join("\n");
+      const doc = makeDocument(text);
+      const ctx = makeCtx(doc, new Position(2, 0), [
+        { name: "ex", range: { start: { line: 0, character: 0 } } },
+      ]);
+
+      const result = await proofContext.call(ctx);
+
+      expect(result.name).toBe("ex");
+      expect(result.full).toBe("Example ex : True. Proof. exact I. Qed. ");
+      // The marker lands at the start of the proof body, after `Proof.`.
+      expect(result.withCursorMarker).toBe(
+        "Example ex : True. Proof. {!* CURSOR *!}exact I. Qed. ",
+      );
+    });
+
+    it("throws when the lemma keyword is not recognised", async () => {
+      // `NonExistantKeyword` is not in the accepted keyword list, so the start
+      // regex fails even though a closer is present.
+      const text = [
+        "NonExistantKeyword ex : True.",
         "Proof.",
         "exact I.",
         "Qed.",

--- a/__tests__/lsp-client/commandExecutor.test.ts
+++ b/__tests__/lsp-client/commandExecutor.test.ts
@@ -1,0 +1,250 @@
+// LLM-generated tests that might codify existing (wrong) behaviour.
+
+import { Position } from "vscode";
+import {
+  executeCommand,
+  executeCommandFullOutput,
+} from "../../src/lsp-client/commandExecutor";
+import {
+  getStateAtPosReq,
+  goalsReq,
+  runReq,
+} from "../../src/lsp-client/petanque";
+import type { RocqLspClient } from "../../src/lsp-client/rocq/client";
+import { makeClientDouble } from "../__helpers__/lsp-client-mocks";
+import type { mocks as MockFactories } from "../__helpers__/lsp-client-mocks";
+
+function lspMocks(): typeof MockFactories {
+  return require("../__helpers__/lsp-client-mocks").mocks; // eslint-disable-line @typescript-eslint/no-require-imports
+}
+
+// commandExecutor only touches `vscode` (Position), `vscode-languageclient`
+// (RequestType, loaded transitively via ./petanque) and
+// `vscode-languageserver-types` (VersionedTextDocumentIdentifier).
+jest.mock("vscode", () => lspMocks().vscode(), { virtual: true });
+jest.mock("vscode-languageclient", () => lspMocks().languageClient(), {
+  virtual: true,
+});
+jest.mock(
+  "vscode-languageserver-types",
+  () => lspMocks().languageServerTypes(),
+  { virtual: true },
+);
+
+const URI = "file:///proof.v";
+const VERSION = 7;
+
+type ClientOverrides = {
+  activeDocument?: unknown;
+  sentenceStart?: Position | undefined;
+};
+
+/**
+ * Build a minimal `RocqLspClient` double. Only the three members the
+ * command executor uses are populated: `activeDocument`,
+ * `getBeginningOfCurrentSentence` and the underlying language `client`.
+ */
+function makeFakeClient(overrides: ClientOverrides = {}) {
+  const languageClient = makeClientDouble();
+
+  const document = {
+    uri: { toString: () => URI },
+    version: VERSION,
+  };
+
+  const client = {
+    activeDocument: "activeDocument" in overrides ? overrides.activeDocument : document,
+    getBeginningOfCurrentSentence: jest.fn(() =>
+      "sentenceStart" in overrides
+        ? overrides.sentenceStart
+        : new Position(4, 5),
+    ),
+    client: languageClient,
+  } as unknown as RocqLspClient;
+
+  return { client, languageClient };
+}
+
+const STATE_RES = { st: 10, proof_finished: false, feedback: [] };
+const RUN_RES = {
+  st: 20,
+  proof_finished: true,
+  feedback: [
+    [1, "hello"],
+    [2, "world"],
+  ] as [number, string][],
+};
+const GOALS_RES = { goals: [{ ty: "True", hyps: [] }], stack: [], bullet: null };
+
+/**
+ * Route `sendRequest` responses by request type so that the three sequential
+ * calls (get_state_at_pos -> run -> goals) each return their own payload.
+ */
+function stubRequests(
+  languageClient: ReturnType<typeof makeClientDouble>,
+  responses: {
+    state?: unknown;
+    run?: unknown;
+    goals?: unknown;
+  } = {},
+) {
+  (languageClient.sendRequest as jest.Mock).mockImplementation(
+    (req: unknown) => {
+      if (req === getStateAtPosReq)
+        return Promise.resolve(responses.state ?? STATE_RES);
+      if (req === runReq) return Promise.resolve(responses.run ?? RUN_RES);
+      if (req === goalsReq) return Promise.resolve(responses.goals ?? GOALS_RES);
+      return Promise.reject(new Error("unexpected request"));
+    },
+  );
+}
+
+describe("commandExecutor", () => {
+  describe("executeCommand", () => {
+    it("returns a GoalAnswer<string> with mapped feedback, goals and document", async () => {
+      const { client, languageClient } = makeFakeClient();
+      stubRequests(languageClient);
+
+      const result = await executeCommand(client, "reflexivity.", new Position(1, 2));
+
+      expect(result.messages).toEqual([
+        { level: 1, text: "hello" },
+        { level: 2, text: "world" },
+      ]);
+      expect(result.position).toEqual(new Position(0, 0));
+      expect(result.textDocument).toEqual({ uri: URI, version: VERSION });
+      expect(result.goals).toBe(GOALS_RES);
+    });
+
+    it("produces an empty messages array when there is no feedback", async () => {
+      const { client, languageClient } = makeFakeClient();
+      stubRequests(languageClient, { run: { ...RUN_RES, feedback: [] } });
+
+      const result = await executeCommand(client, "idtac.", new Position(1, 2));
+
+      expect(result.messages).toEqual([]);
+    });
+  });
+
+  describe("executeCommandFullOutput", () => {
+    it("returns the goals config merged with the run result", async () => {
+      const { client, languageClient } = makeFakeClient();
+      stubRequests(languageClient);
+
+      const result = await executeCommandFullOutput(
+        client,
+        "reflexivity.",
+        new Position(1, 2),
+      );
+
+      expect(result).toEqual({ ...GOALS_RES, ...RUN_RES });
+    });
+  });
+
+  describe("request threading", () => {
+    it("issues get_state_at_pos, run and goals in order with state threaded", async () => {
+      const { client, languageClient } = makeFakeClient();
+      stubRequests(languageClient);
+      const send = languageClient.sendRequest as jest.Mock;
+
+      const pos = new Position(3, 8);
+      await executeCommand(client, "auto.", pos);
+
+      expect(send).toHaveBeenCalledTimes(3);
+
+      const [stateReq, stateParams] = send.mock.calls[0];
+      expect(stateReq).toBe(getStateAtPosReq);
+      expect(stateParams).toEqual({ position: pos, uri: URI });
+
+      const [runRequest, runParams] = send.mock.calls[1];
+      expect(runRequest).toBe(runReq);
+      expect(runParams).toEqual({ st: STATE_RES.st, tac: "auto." });
+
+      const [goalsRequest, goalsParams] = send.mock.calls[2];
+      expect(goalsRequest).toBe(goalsReq);
+      expect(goalsParams).toEqual({ st: RUN_RES.st });
+    });
+  });
+
+  describe("position resolution when pos is omitted", () => {
+    it("uses the sentence start and decrements the character by one", async () => {
+      const { client, languageClient } = makeFakeClient({
+        sentenceStart: new Position(4, 5),
+      });
+      stubRequests(languageClient);
+      const send = languageClient.sendRequest as jest.Mock;
+
+      await executeCommand(client, "auto.");
+
+      expect(client.getBeginningOfCurrentSentence).toHaveBeenCalled();
+      const [, stateParams] = send.mock.calls[0];
+      expect(stateParams.position).toEqual(new Position(4, 4));
+    });
+
+    it("clamps the character to 0 when the sentence starts at character 0", async () => {
+      const { client, languageClient } = makeFakeClient({
+        sentenceStart: new Position(2, 0),
+      });
+      stubRequests(languageClient);
+      const send = languageClient.sendRequest as jest.Mock;
+
+      await executeCommand(client, "auto.");
+
+      const [, stateParams] = send.mock.calls[0];
+      expect(stateParams.position).toEqual(new Position(2, 0));
+    });
+
+    it("prefers the explicit pos and does not consult the sentence start", async () => {
+      const { client, languageClient } = makeFakeClient();
+      stubRequests(languageClient);
+      const send = languageClient.sendRequest as jest.Mock;
+
+      const pos = new Position(9, 9);
+      await executeCommand(client, "auto.", pos);
+
+      expect(client.getBeginningOfCurrentSentence).not.toHaveBeenCalled();
+      const [, stateParams] = send.mock.calls[0];
+      expect(stateParams.position).toBe(pos);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when there is no active document", async () => {
+      const { client } = makeFakeClient({ activeDocument: undefined });
+
+      await expect(
+        executeCommand(client, "auto.", new Position(0, 0)),
+      ).rejects.toThrow("there is no active document");
+    });
+
+    it("throws when pos is omitted and the document has no Coq code", async () => {
+      const { client } = makeFakeClient({ sentenceStart: undefined });
+
+      await expect(executeCommand(client, "auto.")).rejects.toThrow(
+        "contains no Coq code",
+      );
+    });
+
+    it("wraps request failures and includes the command name", async () => {
+      const { client, languageClient } = makeFakeClient();
+      (languageClient.sendRequest as jest.Mock).mockRejectedValue(
+        new Error("boom"),
+      );
+
+      await expect(
+        executeCommand(client, "reflexivity.", new Position(0, 0)),
+      ).rejects.toThrow(/reflexivity\..*boom/);
+    });
+
+    it("also wraps request failures for executeCommandFullOutput", async () => {
+      const { client, languageClient } = makeFakeClient();
+      (languageClient.sendRequest as jest.Mock).mockRejectedValue(
+        new Error("kapow"),
+      );
+
+      await expect(
+        executeCommandFullOutput(client, "lia.", new Position(0, 0)),
+      ).rejects.toThrow(/lia\..*kapow/);
+    });
+  });
+});

--- a/__tests__/lsp-client/commandExecutor.test.ts
+++ b/__tests__/lsp-client/commandExecutor.test.ts
@@ -53,7 +53,8 @@ function makeFakeClient(overrides: ClientOverrides = {}) {
   };
 
   const client = {
-    activeDocument: "activeDocument" in overrides ? overrides.activeDocument : document,
+    activeDocument:
+      "activeDocument" in overrides ? overrides.activeDocument : document,
     getBeginningOfCurrentSentence: jest.fn(() =>
       "sentenceStart" in overrides
         ? overrides.sentenceStart
@@ -74,7 +75,11 @@ const RUN_RES = {
     [2, "world"],
   ] as [number, string][],
 };
-const GOALS_RES = { goals: [{ ty: "True", hyps: [] }], stack: [], bullet: null };
+const GOALS_RES = {
+  goals: [{ ty: "True", hyps: [] }],
+  stack: [],
+  bullet: null,
+};
 
 /**
  * Route `sendRequest` responses by request type so that the three sequential
@@ -93,7 +98,8 @@ function stubRequests(
       if (req === getStateAtPosReq)
         return Promise.resolve(responses.state ?? STATE_RES);
       if (req === runReq) return Promise.resolve(responses.run ?? RUN_RES);
-      if (req === goalsReq) return Promise.resolve(responses.goals ?? GOALS_RES);
+      if (req === goalsReq)
+        return Promise.resolve(responses.goals ?? GOALS_RES);
       return Promise.reject(new Error("unexpected request"));
     },
   );
@@ -105,7 +111,11 @@ describe("commandExecutor", () => {
       const { client, languageClient } = makeFakeClient();
       stubRequests(languageClient);
 
-      const result = await executeCommand(client, "reflexivity.", new Position(1, 2));
+      const result = await executeCommand(
+        client,
+        "reflexivity.",
+        new Position(1, 2),
+      );
 
       expect(result.messages).toEqual([
         { level: 1, text: "hello" },

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { Position, TextDocument } from "vscode";
+import { Position, Range, TextDocument } from "vscode";
 import { RunResult } from "./lsp-client/petanque";
 import { GoalConfig } from "../lib/types";
 
@@ -14,10 +14,12 @@ export type WaterproofAPI = {
     name: string;
     full: string;
     withCursorMarker: string;
+    proofRange: Range;
   }>;
   execCommand: (cmd: string) => Promise<GoalConfig<string> & RunResult<number>>;
   tryProof: (
     steps: string,
+    pos?: Position,
   ) => Promise<{ finished: boolean; remainingGoals: string[] }>;
   cursorPosition: () => Position | undefined;
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -565,7 +565,9 @@ export class Waterproof implements Disposable {
     }
 
     const startRegex = new RegExp(
-      String.raw`(?:Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\s+${firstBefore.name}\s*:\s*[\s\S]*?\.\s+(?:Proof\.)?`,
+      firstBefore.name === "_"
+        ? String.raw`Goal\s*[\s\S]*?\.\s+(?:Proof\.)?`
+        : String.raw`(?:Example|Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\s+${firstBefore.name}\s*:\s*[\s\S]*?\.\s+(?:Proof\.)?`,
       "g",
     );
     // Compute the offset into the document where the proof starts (will be the position before Lemma)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import {
   window,
   ConfigurationTarget,
   Uri,
+  Range,
 } from "vscode";
 import {
   LanguageClientOptions,
@@ -537,6 +538,7 @@ export class Waterproof implements Disposable {
     name: string;
     full: string;
     withCursorMarker: string;
+    proofRange: Range;
   }> {
     if (!this.client.activeDocument || !this.client.activeCursorPosition) {
       throw new Error("No active document or cursor position.");
@@ -548,6 +550,7 @@ export class Waterproof implements Disposable {
 
     // Regex to find the end of the proof the user is working on.
     const endRegex = /(?:Qed|Admitted|Defined)\.\s/;
+
     // We request the document symbols with the goal of finding the lemma the user is working on.
     const symbols = await this.client.requestSymbols();
     const firstBefore = symbols
@@ -560,6 +563,10 @@ export class Waterproof implements Disposable {
     if (firstBefore === undefined) {
       throw new Error("Could not find lemma before cursor.");
     }
+    const startRegex = new RegExp(
+      String.raw`(?:Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\s+${firstBefore.name}\s*:\s*[^.]*\.\s+(?:Proof\.)?`,
+      "g",
+    );
     // Compute the offset into the document where the proof starts (will be the position before Lemma)
     const startProof = document.offsetAt(
       new Position(
@@ -570,16 +577,23 @@ export class Waterproof implements Disposable {
 
     // Get the part of the text of the document starting at the lemma statement.
     const docText = document.getText().substring(startProof);
-    const proofClose = docText.match(endRegex);
+    const proofClose = endRegex.exec(docText);
 
     if (proofClose === null) {
       throw new Error("Could not find end of proof.");
     }
 
-    // Get the text of the proof from the document, we need to add startProof to the index since the regex was run on a su
+    const startMatch = startRegex.exec(docText);
+    if (startMatch === null) {
+      throw new Error("Could not find start of proof.");
+    }
+
+    const proofStart = startProof + startMatch.index + startMatch[0].length;
+
+    // Get the text of the proof from the document
     const theProof = docText.substring(
       0,
-      proofClose.index! + proofClose[0].length,
+      proofClose.index + proofClose[0].length,
     );
 
     // Helper function to remove input-area tags, coq markers and extra whitespace from input string
@@ -602,20 +616,27 @@ export class Waterproof implements Disposable {
           theProof.substring(offsetIntoMatch),
       ),
       name: firstBefore.name,
+      proofRange: new Range(
+        document.positionAt(proofStart),
+        document.positionAt(proofClose.index + startProof),
+      ),
     };
   }
 
   /**
-   * Try a proof/step by executing the given commands/tactics.
+   * Try a proof/step by executing the given commands/tactics at the cursor position.
    * @param steps The proof steps to try. This can be a single tactic or command or multiple separated by the
    * usual `.` and space.
+   * @param pos Optional position at which to try the proof steps.
    */
   public async tryProof(
     steps: string,
+    pos?: Position,
   ): Promise<{ finished: boolean; remainingGoals: string[] }> {
     const execResponse = await executeCommandFullOutput(
       this.client.rocqClient,
       steps,
+      pos,
     );
     return {
       finished: execResponse.proof_finished,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -565,7 +565,7 @@ export class Waterproof implements Disposable {
     }
 
     const startRegex = new RegExp(
-      String.raw`(?:Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\s+${firstBefore.name}\s*:\s*[^.]*\.\s+(?:Proof\.)?`,
+      String.raw`(?:Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\s+${firstBefore.name}\s*:\s*[\s\S]*?\.\s+(?:Proof\.)?`,
       "g",
     );
     // Compute the offset into the document where the proof starts (will be the position before Lemma)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ export class Waterproof implements Disposable {
   /** Main executor that allows for arbitrary execution */
   public readonly executorComponent: IExecutor;
 
-  private sidePanelProvider: SidePanelProvider;
+  private readonly sidePanelProvider: SidePanelProvider;
 
   private clientRunning: boolean = false;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -563,6 +563,7 @@ export class Waterproof implements Disposable {
     if (firstBefore === undefined) {
       throw new Error("Could not find lemma before cursor.");
     }
+
     const startRegex = new RegExp(
       String.raw`(?:Theorem|Lemma|Fact|Remark|Corollary|Proposition|Property)\s+${firstBefore.name}\s*:\s*[^.]*\.\s+(?:Proof\.)?`,
       "g",

--- a/src/lsp-client/commandExecutor.ts
+++ b/src/lsp-client/commandExecutor.ts
@@ -15,25 +15,31 @@ import { RocqLspClient } from "./rocq";
 /**
  * Base function for executing tactics/commands in a client.
  */
-async function executeCommandBase(client: RocqLspClient, command: string) {
+async function executeCommandBase(
+  client: RocqLspClient,
+  command: string,
+  pos?: Position,
+) {
   const document = client.activeDocument;
 
   if (!document) {
     throw new Error("Cannot execute command; there is no active document.");
   }
 
-  // We execute the command at the end of the previous sentence.
-  const commandPosition = client.getBeginningOfCurrentSentence();
-  if (!commandPosition) {
-    throw new Error(
-      "Cannot execute command; the document contains no Rocq code.",
+  if (!pos) {
+    // We execute the command at the end of the previous sentence.
+    const commandPosition = client.getBeginningOfCurrentSentence();
+    if (!commandPosition) {
+      throw new Error(
+        "Cannot execute command; the document contains no Coq code.",
+      );
+    }
+    pos = new Position(
+      commandPosition.line,
+      commandPosition.character > 0 ? commandPosition.character - 1 : 0,
     );
   }
 
-  const pos = {
-    line: commandPosition.line,
-    character: commandPosition.character - 1,
-  };
   const params: GetStateAtPosParams = {
     // Make sure that the position is **before** the dot, otherwise there is no node at the position.
     position: pos,
@@ -69,17 +75,20 @@ async function executeCommandBase(client: RocqLspClient, command: string) {
  * Execute `command` using client `client` and return the output formatted as a valid `GoalAnswer<string>`.
  * @param client The client to use when executing the command.
  * @param command The command/tactic to execute. It is allowed to execute multiple tactics/commands by seperating them using `.`'s.
+ * @param pos Optional position at which to execute the command.
  * @returns The output of executing `command` formatted as a valid `GoalAnswer<string>` object, this can be passed to any component that
  * implement `IGoalsComponent`.
  */
 export async function executeCommand(
   client: RocqLspClient,
   command: string,
+  pos?: Position,
 ): Promise<RocqGoalAnswer<string>> {
   try {
     const { goalsRes, runRes, document } = await executeCommandBase(
       client,
       command,
+      pos,
     );
     // This should form a valid `GoalAnswer<string>`
     return {
@@ -105,14 +114,16 @@ export async function executeCommand(
  * running the command (`RunResult`, this includes messages and whether the proof was finished running `command`)
  * @param client The client to use when executing the command.
  * @param command The command/tactic to execute. It is allowed to execute multiple tactics/commands by seperating them using `.`'s.
+ * @param pos Optional position at which to execute the command.
  * @returns The full output of running `command` using `client`.
  */
 export async function executeCommandFullOutput(
   client: RocqLspClient,
   command: string,
+  pos?: Position,
 ): Promise<GoalConfig<string> & RunResult<number>> {
   try {
-    const { goalsRes, runRes } = await executeCommandBase(client, command);
+    const { goalsRes, runRes } = await executeCommandBase(client, command, pos);
     return { ...goalsRes, ...runRes };
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
- The optional pos argument can be used to execute a proof step at that pos in the document.
- The proof range that is returned is the range of the user written proof in the document.

Both are required for `translateProof` to work in the latest version of River.


