### PR TITLE
Fix webextension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -41,3 +41,4 @@ completions/
 tsconfig.jest.json
 .claude
 hooks/
+coverage/

--- a/__tests__/__helpers__/browser-client-mocks.ts
+++ b/__tests__/__helpers__/browser-client-mocks.ts
@@ -1,0 +1,85 @@
+// Doubles for the web entry point (`src/mainBrowser.ts`).
+//
+// The pieces it wires together — the browser `LanguageClient`, the `Worker` the
+// wacoq server runs in, and the `Waterproof` class — are all replaced so the
+// tests exercise only the entry point's own wiring.
+
+import type { LanguageSupport } from "../../src/lsp-client/clientTypes";
+
+/** Stands in for `BaseLanguageClient.dispose`, so tests can make it reject. */
+export const baseDispose = jest.fn(
+  async (_timeout?: number): Promise<void> => {},
+);
+
+/**
+ * Stand-in for `vscode-languageclient/browser`'s `LanguageClient`.
+ *
+ * `dispose` has to live on the prototype (not be an instance field) for the
+ * `super.dispose(...)` call in `WorkerLanguageClient` to reach it.
+ */
+export class FakeBrowserLanguageClient {
+  constructor(
+    public readonly id: string,
+    public readonly name: string,
+    public readonly clientOptions: unknown,
+    public readonly worker: unknown,
+  ) {}
+
+  async dispose(timeout?: number): Promise<void> {
+    await baseDispose(timeout);
+  }
+}
+
+/** Stand-in for the DOM `Worker`, recording every instance created. */
+export class FakeWorker {
+  static readonly created: FakeWorker[] = [];
+
+  public readonly postMessage = jest.fn();
+  public readonly terminate = jest.fn();
+
+  constructor(public readonly url: string) {
+    FakeWorker.created.push(this);
+  }
+}
+
+/** The arguments every `Waterproof` constructed by `activate` was given. */
+export const waterproofInstances: {
+  languageSupport: LanguageSupport;
+  isWeb: boolean;
+}[] = [];
+
+export function resetBrowserMocks(): void {
+  FakeWorker.created.length = 0;
+  waterproofInstances.length = 0;
+  baseDispose.mockClear();
+  baseDispose.mockResolvedValue(undefined);
+}
+
+/**
+ * Module factories for `jest.mock`.
+ *
+ * Call these through a local `require` inside the mock factory, as jest hoists
+ * `jest.mock` above the imports.
+ */
+export const browserMocks = {
+  vscodeModule: () => ({
+    Uri: {
+      joinPath: (base: { toString(): string }, ...parts: string[]) => ({
+        toString: () => [base.toString(), ...parts].join("/"),
+      }),
+    },
+  }),
+  languageClientModule: () => ({ LanguageClient: FakeBrowserLanguageClient }),
+  extensionModule: () => ({
+    Waterproof: class Waterproof {
+      public readonly initializeClient = jest.fn();
+      constructor(
+        _context: unknown,
+        languageSupport: LanguageSupport,
+        isWeb: boolean,
+      ) {
+        waterproofInstances.push({ languageSupport, isWeb });
+      }
+    },
+  }),
+};

--- a/__tests__/__helpers__/composite-mocks.ts
+++ b/__tests__/__helpers__/composite-mocks.ts
@@ -1,0 +1,108 @@
+// Shared doubles for tests around `CompositeClient`.
+//
+// `CompositeClient` constructs a `RocqLspClient` and (when configured) a
+// `LeanLspClient`. Both are replaced by `FakeLspClient` subclasses so the tests
+// exercise only the composite's own routing and lifecycle logic.
+
+import type {
+  LanguageClientSetup,
+  LanguageClientSetups,
+} from "../../src/lsp-client/clientTypes";
+
+/**
+ * Stand-in for an `LspClient`, exposing the surface `CompositeClient` touches.
+ *
+ * Defaults are deliberately inert (nothing running, no languages allowed) so a
+ * test only has to set up the parts it cares about.
+ */
+export class FakeLspClient {
+  public language = "";
+  /** Mirrors `LspClient.hasClient`: a client was created, running or not. */
+  public hasClient = false;
+  public activeDocument: unknown = undefined;
+  public activeCursorPosition: unknown = undefined;
+
+  public readonly isRunning = jest.fn<boolean, []>(() => false);
+  public readonly prelaunchChecks = jest.fn(async (): Promise<string[]> => []);
+  public readonly startWithHandlers = jest.fn(
+    async (): Promise<string[]> => [],
+  );
+  public readonly dispose = jest.fn(async (): Promise<void> => {});
+  public readonly requestSymbols = jest.fn(async () => []);
+  public readonly updateCompletions = jest.fn(async () => {});
+  public readonly sendViewportHint = jest.fn();
+  public readonly requestGoals = jest.fn();
+
+  /** The arguments `CompositeClient` constructed this client with. */
+  constructor(public readonly ctorArgs: unknown[]) {}
+}
+
+/** Every fake client constructed since the last {@link resetCreatedClients}. */
+export const createdClients: { rocq: FakeLspClient[]; lean: FakeLspClient[] } =
+  {
+    rocq: [],
+    lean: [],
+  };
+
+export function resetCreatedClients(): void {
+  createdClients.rocq.length = 0;
+  createdClients.lean.length = 0;
+}
+
+/**
+ * Module factories for `jest.mock`.
+ *
+ * Call these through a local `require` inside the mock factory, as jest hoists
+ * `jest.mock` above the imports.
+ */
+export const compositeMocks = {
+  rocqModule: () => ({
+    RocqLspClient: class RocqLspClient extends FakeLspClient {
+      constructor(...args: unknown[]) {
+        super(args);
+        this.language = "rocq";
+        createdClients.rocq.push(this);
+      }
+    },
+  }),
+  leanModule: () => ({
+    LeanLspClient: class LeanLspClient extends FakeLspClient {
+      constructor(...args: unknown[]) {
+        super(args);
+        this.language = "lean4";
+        createdClients.lean.push(this);
+      }
+    },
+  }),
+  helpers: () => ({
+    WaterproofLogger: { log: jest.fn(), debug: jest.fn(), show: jest.fn() },
+  }),
+};
+
+/** A `LanguageClientSetup` whose provider and channel factory are spies. */
+export type SpySetup = LanguageClientSetup & {
+  provider: jest.Mock;
+  createOutputChannel: jest.Mock;
+};
+
+export function makeSetup(): SpySetup {
+  return {
+    provider: jest.fn(() => ({}) as never),
+    createOutputChannel: jest.fn(
+      () => ({ appendLine: jest.fn(), dispose: jest.fn() }) as never,
+    ),
+  };
+}
+
+/** Setups for a build that supports Rocq only (the web extension). */
+export function rocqOnlySetups(): LanguageClientSetups & { rocq: SpySetup } {
+  return { rocq: makeSetup() };
+}
+
+/** Setups for a build that supports both languages (the desktop extension). */
+export function bothSetups(): LanguageClientSetups & {
+  rocq: SpySetup;
+  lean: SpySetup;
+} {
+  return { rocq: makeSetup(), lean: makeSetup() };
+}

--- a/__tests__/__helpers__/extension-mocks.ts
+++ b/__tests__/__helpers__/extension-mocks.ts
@@ -1,0 +1,119 @@
+// Shared module factories for tests around the `Waterproof` extension class.
+//
+// `src/extension.ts` pulls in the whole activation path, so tests mock the
+// module graph away and exercise prototype methods with a hand-rolled `this`
+// context. These factories keep that (long) preamble in one place.
+//
+// Call them through a local `require` inside the `jest.mock` factory, as jest
+// hoists `jest.mock` above the imports.
+
+import type { LanguageClientSetups } from "../../src/lsp-client/clientTypes";
+
+/** The arguments every mocked `CompositeClient` was constructed with. */
+export const createdComposites: {
+  setups: LanguageClientSetups;
+  context: unknown;
+}[] = [];
+
+export function resetExtensionMocks(): void {
+  createdComposites.length = 0;
+}
+
+export const extensionMocks = {
+  vscode: () => ({
+    Position: class {
+      constructor(
+        public line: number,
+        public character: number,
+      ) {}
+    },
+    commands: {
+      registerCommand: jest.fn(),
+      registerTextEditorCommand: jest.fn(),
+      executeCommand: jest.fn(),
+    },
+    window: {
+      createOutputChannel: jest.fn((name: string) => ({
+        name,
+        appendLine: jest.fn(),
+        dispose: jest.fn(),
+      })),
+    },
+    workspace: {},
+    ConfigurationTarget: { Global: 1 },
+    Uri: { parse: jest.fn(), joinPath: jest.fn() },
+    RevealOutputChannelOn: { Info: 1 },
+  }),
+
+  languageClient: () => ({ RevealOutputChannelOn: { Info: 1 } }),
+
+  commandExecutor: () => ({
+    executeCommand: jest.fn(),
+    executeCommandFullOutput: jest.fn(),
+  }),
+
+  helpers: () => ({
+    WaterproofLogger: { log: jest.fn(), debug: jest.fn(), show: jest.fn() },
+    WaterproofConfigHelper: {
+      get: jest.fn(),
+      update: jest.fn(),
+      configuration: {},
+    },
+    WaterproofFileUtil: {},
+    WaterproofPackageJSON: {
+      // `initializeClient` slices the leading ">=" off this.
+      requiredCoqLspVersion: jest.fn(() => ">=0.2.4"),
+      requiredCoqWaterproofVersion: jest.fn(() => ">=3.1.0"),
+    },
+    WaterproofSetting: { SkipLaunchChecks: "skipLaunchChecks" },
+  }),
+
+  pmEditor: () => ({ WaterproofEditorProvider: { register: jest.fn() } }),
+
+  util: () => ({
+    // `initializeClient` attaches a `.catch` to this, so it has to be thenable.
+    checkConflictingExtensions: jest.fn(() => Promise.resolve()),
+    excludeRocqFileTypes: jest.fn(),
+    checkTrimmingWhitespace: jest.fn(),
+  }),
+
+  enableButton: () => ({ WaterproofStatusBar: class {} }),
+  sidePanel: () => ({ addSidePanel: jest.fn(), SidePanelProvider: class {} }),
+  search: () => ({ Search: class {} }),
+  execute: () => ({ ExecutePanel: class {} }),
+  symbols: () => ({ SymbolsPanel: class {} }),
+  tactics: () => ({ TacticsPanel: class {} }),
+  debugPanel: () => ({ DebugPanel: class {} }),
+  goalsPanel: () => ({ GoalsPanel: class {} }),
+  compositeGoalsPanel: () => ({ CompositeGoalsPanel: class {} }),
+  exerciseSheet: () => ({ clearInputCells: jest.fn() }),
+
+  rocq: () => ({ RocqLspServerConfig: { create: jest.fn() } }),
+  lean: () => ({ LeanLspServerConfig: { create: jest.fn() } }),
+
+  /**
+   * `CompositeClient` recording what `initializeClient` built it from, with an
+   * inert client surface so the rest of `initializeClient` can run.
+   */
+  composite: () => ({
+    CompositeClient: class CompositeClient {
+      public readonly startWithHandlers = jest.fn(
+        async (): Promise<string[]> => [],
+      );
+      public readonly prelaunchChecks = jest.fn(
+        async (): Promise<string[]> => [],
+      );
+      public readonly dispose = jest.fn(async (): Promise<void> => {});
+      public readonly isRunning = jest.fn(() => false);
+
+      constructor(setups: LanguageClientSetups, context: unknown) {
+        createdComposites.push({ setups, context });
+      }
+    },
+  }),
+};
+
+/** A document double identified only by its uri. */
+export function doc(uri: string): { uri: { toString: () => string } } {
+  return { uri: { toString: () => uri } };
+}

--- a/__tests__/extension/clientLifecycle.test.ts
+++ b/__tests__/extension/clientLifecycle.test.ts
@@ -1,0 +1,297 @@
+// Unit tests for initializeClient / stopClient on the Waterproof extension class.
+//
+// LLM-generated tests that might encode existing faulty behaviour.
+//
+// Which languages a build supports is now decided by the entry point: it hands
+// over a `LanguageSupport`, and Lean is configured only when that record has a
+// `lean` factory. What is covered here:
+//   - a Rocq-only support record producing no Lean setup and no Lean server
+//     config (the web extension),
+//   - a full support record producing both, each with its own client options,
+//   - the output channels being created lazily, so an unsupported language
+//     leaves no empty channel behind,
+//   - the web build skipping the prelaunch checks (they shell out through
+//     child_process, which a web build cannot do),
+//   - stopClient disposing a client that was created but never started.
+//
+// Like the event-handler tests, these invoke the (private) prototype methods
+// with a hand-rolled `this` rather than constructing the whole extension.
+
+function helperMocks(): typeof import("../__helpers__/extension-mocks").extensionMocks {
+  return require("../__helpers__/extension-mocks").extensionMocks; // eslint-disable-line @typescript-eslint/no-require-imports
+}
+
+jest.mock("vscode", () => helperMocks().vscode(), { virtual: true });
+jest.mock("vscode-languageclient", () => helperMocks().languageClient(), {
+  virtual: true,
+});
+jest.mock("../../src/lsp-client/commandExecutor", () =>
+  helperMocks().commandExecutor(),
+);
+jest.mock("../../src/helpers", () => helperMocks().helpers());
+jest.mock("../../src/pm-editor", () => helperMocks().pmEditor());
+jest.mock("../../src/util", () => helperMocks().util());
+jest.mock("../../src/components/enableButton", () =>
+  helperMocks().enableButton(),
+);
+jest.mock("../../src/webviews/sidePanel", () => helperMocks().sidePanel());
+jest.mock("../../src/webviews/standardviews/search", () =>
+  helperMocks().search(),
+);
+jest.mock("../../src/webviews/standardviews/execute", () =>
+  helperMocks().execute(),
+);
+jest.mock("../../src/webviews/standardviews/symbols", () =>
+  helperMocks().symbols(),
+);
+jest.mock("../../src/webviews/standardviews/tactics", () =>
+  helperMocks().tactics(),
+);
+jest.mock("../../src/webviews/goalviews/debug", () =>
+  helperMocks().debugPanel(),
+);
+jest.mock("../../src/webviews/goalviews/goalsPanel", () =>
+  helperMocks().goalsPanel(),
+);
+jest.mock("../../src/webviews/goalviews/compositeGoalsPanel", () =>
+  helperMocks().compositeGoalsPanel(),
+);
+jest.mock("../../src/lsp-client/composite", () => helperMocks().composite());
+jest.mock("../../src/lsp-client/rocq", () => helperMocks().rocq());
+jest.mock("../../src/lsp-client/lean", () => helperMocks().lean());
+jest.mock("../../src/helpers/exerciseSheet", () =>
+  helperMocks().exerciseSheet(),
+);
+
+import { window } from "vscode";
+import { Waterproof } from "../../src/extension";
+import { WaterproofConfigHelper } from "../../src/helpers";
+import { LeanLspServerConfig } from "../../src/lsp-client/lean";
+import {
+  createdComposites,
+  resetExtensionMocks,
+} from "../__helpers__/extension-mocks";
+import type {
+  LanguageClientProviderFactory,
+  LanguageSupport,
+} from "../../src/lsp-client/clientTypes";
+
+const createOutputChannel = window.createOutputChannel as jest.Mock;
+const configGet = WaterproofConfigHelper.get as jest.Mock;
+const leanConfigCreate = LeanLspServerConfig.create as jest.Mock;
+
+/** A language-client provider factory that records how it was called. */
+function makeFactory(): jest.Mock & LanguageClientProviderFactory {
+  return jest.fn(() => jest.fn()) as unknown as jest.Mock &
+    LanguageClientProviderFactory;
+}
+
+type Ctx = {
+  context: Record<string, unknown>;
+  languageSupport: LanguageSupport;
+  _isWeb: boolean;
+  client?: unknown;
+  clientRunning: boolean;
+  statusBar: { update: jest.Mock; failed: jest.Mock };
+  webviewManager: { open: jest.Mock };
+};
+
+function makeCtx(overrides: Partial<Ctx> = {}): Ctx {
+  return {
+    context: {},
+    languageSupport: { rocq: makeFactory() },
+    _isWeb: false,
+    client: undefined,
+    clientRunning: false,
+    statusBar: { update: jest.fn(), failed: jest.fn() },
+    webviewManager: { open: jest.fn() },
+    ...overrides,
+  };
+}
+
+const proto = Waterproof.prototype as unknown as {
+  initializeClient: (this: unknown) => Promise<void>;
+  stopClient: (this: unknown) => Promise<void>;
+};
+
+/** The `LanguageClientSetups` that `initializeClient` built the composite from. */
+function setups() {
+  expect(createdComposites).toHaveLength(1);
+  return createdComposites[0].setups;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetExtensionMocks();
+  configGet.mockReturnValue("none");
+});
+
+describe("initializeClient language wiring", () => {
+  it("builds no Lean setup when the entry point supports only Rocq", async () => {
+    const ctx = makeCtx({
+      languageSupport: { rocq: makeFactory() },
+      _isWeb: true,
+    });
+
+    await proto.initializeClient.call(ctx);
+
+    expect(setups().rocq).toBeDefined();
+    expect(setups().lean).toBeUndefined();
+    // Nothing should even compute the Lean server options.
+    expect(leanConfigCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates no output channel for an unsupported language", async () => {
+    const ctx = makeCtx({
+      languageSupport: { rocq: makeFactory() },
+      _isWeb: true,
+    });
+
+    await proto.initializeClient.call(ctx);
+
+    // The channels are thunks the composite calls, so initializeClient itself
+    // creates none; and there is no Lean thunk to call at all.
+    expect(createOutputChannel).not.toHaveBeenCalled();
+    expect(setups().rocq.createOutputChannel()).toEqual(
+      expect.objectContaining({
+        name: "Waterproof Rocq LSP Events (After Initialization)",
+      }),
+    );
+  });
+
+  it("builds both setups when the entry point supports Lean too", async () => {
+    const rocq = makeFactory();
+    const lean = makeFactory();
+
+    await proto.initializeClient.call(
+      makeCtx({ languageSupport: { rocq, lean } }),
+    );
+
+    expect(setups().lean).toBeDefined();
+    expect(leanConfigCreate).toHaveBeenCalledTimes(1);
+    expect(setups().lean?.createOutputChannel()).toEqual(
+      expect.objectContaining({
+        name: "Waterproof Lean LSP Events (After Initialization)",
+      }),
+    );
+  });
+
+  it("gives each factory its own language's client options", async () => {
+    const rocq = makeFactory();
+    const lean = makeFactory();
+    const ctx = makeCtx({ languageSupport: { rocq, lean } });
+
+    await proto.initializeClient.call(ctx);
+
+    expect(rocq).toHaveBeenCalledTimes(1);
+    expect(lean).toHaveBeenCalledTimes(1);
+    expect(rocq.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        documentSelector: [{ language: "markdown" }, { language: "coq" }],
+      }),
+    );
+    expect(lean.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ documentSelector: [{ language: "lean4" }] }),
+    );
+    // Both are handed the extension context they were registered with.
+    expect(rocq.mock.calls[0][0]).toBe(ctx.context);
+  });
+
+  it("passes each factory's provider to the matching setup", async () => {
+    const rocqProvider = jest.fn();
+    const rocq = jest.fn(
+      () => rocqProvider,
+    ) as unknown as LanguageClientProviderFactory;
+
+    await proto.initializeClient.call(makeCtx({ languageSupport: { rocq } }));
+
+    expect(setups().rocq.provider).toBe(rocqProvider);
+  });
+});
+
+describe("initializeClient launch checks", () => {
+  it("skips the prelaunch checks in the web build", async () => {
+    configGet.mockReturnValue("none");
+    const ctx = makeCtx({ _isWeb: true });
+
+    await proto.initializeClient.call(ctx);
+
+    const composite = ctx.client as {
+      prelaunchChecks: jest.Mock;
+      startWithHandlers: jest.Mock;
+    };
+    // The checks shell out through child_process, which a web build cannot do.
+    expect(composite.prelaunchChecks).not.toHaveBeenCalled();
+    expect(composite.startWithHandlers).toHaveBeenCalledWith(
+      ctx.webviewManager,
+      ["rocq"],
+    );
+  });
+
+  it("runs the prelaunch checks on desktop when the user has not skipped them", async () => {
+    configGet.mockReturnValue("none");
+    const ctx = makeCtx({ _isWeb: false });
+
+    await proto.initializeClient.call(ctx);
+
+    const composite = ctx.client as { prelaunchChecks: jest.Mock };
+    expect(composite.prelaunchChecks).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours an explicit skip setting on desktop", async () => {
+    configGet.mockReturnValue("all");
+    const ctx = makeCtx({ _isWeb: false });
+
+    await proto.initializeClient.call(ctx);
+
+    const composite = ctx.client as {
+      prelaunchChecks: jest.Mock;
+      startWithHandlers: jest.Mock;
+    };
+    expect(composite.prelaunchChecks).not.toHaveBeenCalled();
+    expect(composite.startWithHandlers).toHaveBeenCalledWith(
+      ctx.webviewManager,
+      ["rocq", "lean4"],
+    );
+  });
+});
+
+describe("stopClient", () => {
+  function clientDouble(isRunning: boolean) {
+    return {
+      isRunning: jest.fn(() => isRunning),
+      dispose: jest.fn(async () => {}),
+    };
+  }
+
+  it("disposes a client that was created but never started", async () => {
+    // Regression test: guarding on isRunning left such a client undisposed, so
+    // the next initializeClient orphaned the resources it owned.
+    const client = clientDouble(false);
+    const ctx = makeCtx({ client, clientRunning: false });
+
+    await proto.stopClient.call(ctx);
+
+    expect(client.dispose).toHaveBeenCalledWith(2000);
+  });
+
+  it("does not report a stop for a client that was not running", async () => {
+    const client = clientDouble(false);
+    const ctx = makeCtx({ client, clientRunning: false });
+
+    await proto.stopClient.call(ctx);
+
+    expect(ctx.statusBar.update).not.toHaveBeenCalled();
+  });
+
+  it("disposes a running client and clears the status bar", async () => {
+    const client = clientDouble(true);
+    const ctx = makeCtx({ client, clientRunning: true });
+
+    await proto.stopClient.call(ctx);
+
+    expect(client.dispose).toHaveBeenCalledWith(2000);
+    expect(ctx.clientRunning).toBe(false);
+    expect(ctx.statusBar.update).toHaveBeenCalledWith([]);
+  });
+});

--- a/__tests__/extension/eventHandlers.test.ts
+++ b/__tests__/extension/eventHandlers.test.ts
@@ -8,122 +8,60 @@
 // .call(fakeThis, ...)`) instead of constructing the full extension, which would
 // pull in the entire VS Code activation path.
 
-jest.mock(
-  "vscode",
-  () => ({
-    Position: class {
-      constructor(
-        public line: number,
-        public character: number,
-      ) {}
-    },
-    commands: {
-      registerCommand: jest.fn(),
-      registerTextEditorCommand: jest.fn(),
-      executeCommand: jest.fn(),
-    },
-    window: {
-      createOutputChannel: jest.fn(() => ({
-        appendLine: jest.fn(),
-        dispose: jest.fn(),
-      })),
-    },
-    workspace: {},
-    ConfigurationTarget: { Global: 1 },
-    Uri: { parse: jest.fn(), joinPath: jest.fn() },
-    RevealOutputChannelOn: { Info: 1 },
-  }),
-  { virtual: true },
+function helperMocks(): typeof import("../__helpers__/extension-mocks").extensionMocks {
+  return require("../__helpers__/extension-mocks").extensionMocks; // eslint-disable-line @typescript-eslint/no-require-imports
+}
+
+jest.mock("vscode", () => helperMocks().vscode(), { virtual: true });
+jest.mock("vscode-languageclient", () => helperMocks().languageClient(), {
+  virtual: true,
+});
+jest.mock("../../src/lsp-client/commandExecutor", () =>
+  helperMocks().commandExecutor(),
 );
-
-jest.mock(
-  "vscode-languageclient",
-  () => ({
-    RevealOutputChannelOn: { Info: 1 },
-  }),
-  { virtual: true },
+jest.mock("../../src/helpers", () => helperMocks().helpers());
+jest.mock("../../src/pm-editor", () => helperMocks().pmEditor());
+jest.mock("../../src/util", () => helperMocks().util());
+jest.mock("../../src/components/enableButton", () =>
+  helperMocks().enableButton(),
 );
-
-// The handlers only touch a couple of collaborators; everything else imported by
-// extension.ts is mocked away so the module loads cheaply.
-jest.mock("../../src/lsp-client/commandExecutor", () => ({
-  executeCommand: jest.fn(),
-  executeCommandFullOutput: jest.fn(),
-}));
-jest.mock("../../src/helpers", () => ({
-  WaterproofLogger: { log: jest.fn(), debug: jest.fn(), show: jest.fn() },
-  WaterproofConfigHelper: {
-    get: jest.fn(),
-    update: jest.fn(),
-    configuration: {},
-  },
-  WaterproofFileUtil: {},
-  WaterproofPackageJSON: {},
-  WaterproofSetting: {},
-}));
-
-// The remaining imports of extension.ts are only used to build the live
-// extension; for these tests we just need them to be loadable.
-jest.mock("../../src/pm-editor", () => ({
-  WaterproofEditorProvider: { register: jest.fn() },
-}));
-jest.mock("../../src/util", () => ({
-  checkConflictingExtensions: jest.fn(),
-  excludeRocqFileTypes: jest.fn(),
-  checkTrimmingWhitespace: jest.fn(),
-}));
-jest.mock("../../src/components/enableButton", () => ({
-  WaterproofStatusBar: class {},
-}));
-jest.mock("../../src/webviews/sidePanel", () => ({
-  addSidePanel: jest.fn(),
-  SidePanelProvider: class {},
-}));
-jest.mock("../../src/webviews/standardviews/search", () => ({
-  Search: class {},
-}));
-jest.mock("../../src/webviews/standardviews/execute", () => ({
-  ExecutePanel: class {},
-}));
-jest.mock("../../src/webviews/standardviews/symbols", () => ({
-  SymbolsPanel: class {},
-}));
-jest.mock("../../src/webviews/standardviews/tactics", () => ({
-  TacticsPanel: class {},
-}));
-jest.mock("../../src/webviews/goalviews/debug", () => ({
-  DebugPanel: class {},
-}));
-jest.mock("../../src/webviews/goalviews/goalsPanel", () => ({
-  GoalsPanel: class {},
-}));
-jest.mock("../../src/webviews/goalviews/compositeGoalsPanel", () => ({
-  CompositeGoalsPanel: class {},
-}));
-jest.mock("../../src/lsp-client/composite", () => ({
-  CompositeClient: class {},
-}));
-jest.mock("../../src/lsp-client/rocq", () => ({
-  RocqLspServerConfig: { create: jest.fn() },
-}));
-jest.mock("../../src/lsp-client/lean", () => ({
-  LeanLspServerConfig: { create: jest.fn() },
-}));
-jest.mock("../../src/helpers/exerciseSheet", () => ({
-  clearInputCells: jest.fn(),
-}));
+jest.mock("../../src/webviews/sidePanel", () => helperMocks().sidePanel());
+jest.mock("../../src/webviews/standardviews/search", () =>
+  helperMocks().search(),
+);
+jest.mock("../../src/webviews/standardviews/execute", () =>
+  helperMocks().execute(),
+);
+jest.mock("../../src/webviews/standardviews/symbols", () =>
+  helperMocks().symbols(),
+);
+jest.mock("../../src/webviews/standardviews/tactics", () =>
+  helperMocks().tactics(),
+);
+jest.mock("../../src/webviews/goalviews/debug", () =>
+  helperMocks().debugPanel(),
+);
+jest.mock("../../src/webviews/goalviews/goalsPanel", () =>
+  helperMocks().goalsPanel(),
+);
+jest.mock("../../src/webviews/goalviews/compositeGoalsPanel", () =>
+  helperMocks().compositeGoalsPanel(),
+);
+jest.mock("../../src/lsp-client/composite", () => helperMocks().composite());
+jest.mock("../../src/lsp-client/rocq", () => helperMocks().rocq());
+jest.mock("../../src/lsp-client/lean", () => helperMocks().lean());
+jest.mock("../../src/helpers/exerciseSheet", () =>
+  helperMocks().exerciseSheet(),
+);
 
 import { Position } from "vscode";
 import { Waterproof } from "../../src/extension";
 import { executeCommand } from "../../src/lsp-client/commandExecutor";
+import { doc } from "../__helpers__/extension-mocks";
 
 const executeCommandMock = executeCommand as jest.Mock;
 
-type FakeDoc = { uri: { toString: () => string } };
-
-function doc(uri: string): FakeDoc {
-  return { uri: { toString: () => uri } };
-}
+type FakeDoc = ReturnType<typeof doc>;
 
 // Minimal stand-in for the `this` context the handlers rely on.
 function makeCtx(overrides: Record<string, unknown> = {}) {

--- a/__tests__/lsp-client/composite.test.ts
+++ b/__tests__/lsp-client/composite.test.ts
@@ -1,0 +1,251 @@
+// Unit tests for CompositeClient's handling of an optional Lean client.
+//
+// LLM-generated tests that might encode existing faulty behaviour.
+//
+// A build that cannot run a Lean server (the web extension, which has no way to
+// spawn a Lake process) supplies no `lean` entry in its `LanguageClientSetups`.
+// The composite then has to behave as a Rocq-only client without any caller
+// having to know about it. What is covered here:
+//   - which clients (and output channels) the constructor creates,
+//   - prelaunchChecks / isRunning / startWithHandlers with Lean absent,
+//   - dispose guarding on `hasClient` rather than `isRunning`, so a client that
+//     was created but failed to start is still released.
+//
+// `getClient`'s lean4-when-Lean-is-unsupported branch is deliberately left
+// uncovered: that fallback is a known wart whose behaviour is not yet settled.
+
+function helperMocks(): typeof import("../__helpers__/composite-mocks").compositeMocks {
+  return require("../__helpers__/composite-mocks").compositeMocks; // eslint-disable-line @typescript-eslint/no-require-imports
+}
+
+jest.mock("vscode", () => ({}), { virtual: true });
+jest.mock("../../src/lsp-client/rocq", () => helperMocks().rocqModule());
+jest.mock("../../src/lsp-client/lean", () => helperMocks().leanModule());
+jest.mock("../../src/helpers", () => helperMocks().helpers());
+jest.mock("../../lib/types", () => ({ convertToString: jest.fn() }), {
+  virtual: true,
+});
+
+import { CompositeClient } from "../../src/lsp-client/composite";
+import {
+  bothSetups,
+  createdClients,
+  resetCreatedClients,
+  rocqOnlySetups,
+  type FakeLspClient,
+} from "../__helpers__/composite-mocks";
+import type { ExtensionContext } from "vscode";
+import type { WebviewManager } from "../../src/webviewManager";
+
+const context = {} as ExtensionContext;
+const webviewManager = {} as WebviewManager;
+
+/** The Rocq double the composite constructed (typed for convenience). */
+function rocqDouble(client: CompositeClient): FakeLspClient {
+  return client.rocqClient as unknown as FakeLspClient;
+}
+
+/** The Lean double the composite constructed. Fails if there is none. */
+function leanDouble(client: CompositeClient): FakeLspClient {
+  if (!client.leanClient) throw new Error("expected a Lean client");
+  return client.leanClient as unknown as FakeLspClient;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetCreatedClients();
+});
+
+describe("CompositeClient construction", () => {
+  it("creates no Lean client when the setups have no lean entry", () => {
+    const setups = rocqOnlySetups();
+
+    const client = new CompositeClient(setups, context);
+
+    expect(client.rocqClient).toBeDefined();
+    expect(client.leanClient).toBeUndefined();
+    expect(createdClients.lean).toHaveLength(0);
+    expect(createdClients.rocq).toHaveLength(1);
+  });
+
+  it("creates no Lean output channel when Lean is unsupported", () => {
+    const setups = rocqOnlySetups();
+
+    new CompositeClient(setups, context);
+
+    // The Rocq channel is created eagerly; there is no Lean setup at all, so
+    // nothing can create a channel for a server that can never start.
+    expect(setups.rocq.createOutputChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates both clients, each with its own provider and channel", () => {
+    const setups = bothSetups();
+    const rocqChannel = { id: "rocq-channel" };
+    const leanChannel = { id: "lean-channel" };
+    setups.rocq.createOutputChannel.mockReturnValue(rocqChannel);
+    setups.lean.createOutputChannel.mockReturnValue(leanChannel);
+
+    const client = new CompositeClient(setups, context);
+
+    expect(client.leanClient).toBeDefined();
+    expect(setups.lean.createOutputChannel).toHaveBeenCalledTimes(1);
+    // Each client gets its own language's provider and channel, in that order.
+    expect(rocqDouble(client).ctorArgs).toEqual([
+      setups.rocq.provider,
+      rocqChannel,
+      context,
+    ]);
+    expect(leanDouble(client).ctorArgs).toEqual([
+      setups.lean.provider,
+      leanChannel,
+    ]);
+  });
+
+  it("does not invoke the providers itself", () => {
+    // The provider is a thunk the client calls lazily; the composite only
+    // hands it on. Calling it here would start a language server eagerly.
+    const setups = bothSetups();
+
+    new CompositeClient(setups, context);
+
+    expect(setups.rocq.provider).not.toHaveBeenCalled();
+    expect(setups.lean.provider).not.toHaveBeenCalled();
+  });
+});
+
+describe("CompositeClient.prelaunchChecks", () => {
+  it("returns only the Rocq languages when Lean is unsupported", async () => {
+    const client = new CompositeClient(rocqOnlySetups(), context);
+    rocqDouble(client).prelaunchChecks.mockResolvedValue(["rocq"]);
+
+    await expect(client.prelaunchChecks()).resolves.toEqual(["rocq"]);
+  });
+
+  it("concatenates the languages of both clients", async () => {
+    const client = new CompositeClient(bothSetups(), context);
+    rocqDouble(client).prelaunchChecks.mockResolvedValue(["rocq"]);
+    leanDouble(client).prelaunchChecks.mockResolvedValue(["lean4"]);
+
+    await expect(client.prelaunchChecks()).resolves.toEqual(["rocq", "lean4"]);
+  });
+});
+
+describe("CompositeClient.isRunning", () => {
+  it("follows the Rocq client when Lean is unsupported", () => {
+    const client = new CompositeClient(rocqOnlySetups(), context);
+
+    expect(client.isRunning()).toBe(false);
+
+    rocqDouble(client).isRunning.mockReturnValue(true);
+    expect(client.isRunning()).toBe(true);
+  });
+
+  it("is true when either client runs", () => {
+    const client = new CompositeClient(bothSetups(), context);
+
+    expect(client.isRunning()).toBe(false);
+
+    leanDouble(client).isRunning.mockReturnValue(true);
+    expect(client.isRunning()).toBe(true);
+  });
+});
+
+describe("CompositeClient.startWithHandlers", () => {
+  it("starts only Rocq when Lean is unsupported", async () => {
+    const client = new CompositeClient(rocqOnlySetups(), context);
+    rocqDouble(client).startWithHandlers.mockResolvedValue(["rocq"]);
+
+    const started = await client.startWithHandlers(webviewManager, [
+      "rocq",
+      "lean4",
+    ]);
+
+    // "lean4" being allowed must not resurrect a client that does not exist.
+    expect(started).toEqual(["rocq"]);
+    expect(rocqDouble(client).startWithHandlers).toHaveBeenCalledWith(
+      webviewManager,
+      ["rocq", "lean4"],
+    );
+  });
+
+  it("starts both clients when both are supported and allowed", async () => {
+    const client = new CompositeClient(bothSetups(), context);
+    rocqDouble(client).startWithHandlers.mockResolvedValue(["rocq"]);
+    leanDouble(client).startWithHandlers.mockResolvedValue(["lean4"]);
+
+    const started = await client.startWithHandlers(webviewManager, [
+      "rocq",
+      "lean4",
+    ]);
+
+    expect(started).toEqual(["rocq", "lean4"]);
+  });
+
+  it("skips a supported client whose language is not allowed", async () => {
+    const client = new CompositeClient(bothSetups(), context);
+    rocqDouble(client).startWithHandlers.mockResolvedValue(["rocq"]);
+
+    const started = await client.startWithHandlers(webviewManager, ["rocq"]);
+
+    expect(started).toEqual(["rocq"]);
+    expect(leanDouble(client).startWithHandlers).not.toHaveBeenCalled();
+  });
+
+  it("keeps the other client running when one fails to start", async () => {
+    const client = new CompositeClient(bothSetups(), context);
+    rocqDouble(client).startWithHandlers.mockResolvedValue(["rocq"]);
+    leanDouble(client).startWithHandlers.mockRejectedValue(new Error("boom"));
+
+    const started = await client.startWithHandlers(webviewManager, [
+      "rocq",
+      "lean4",
+    ]);
+
+    expect(started).toEqual(["rocq"]);
+  });
+});
+
+describe("CompositeClient.dispose", () => {
+  it("disposes a client that was created but never started", async () => {
+    // Regression test: guarding on `isRunning` left a failed-start client
+    // undisposed, orphaning the resources it owns (in the web build, the
+    // worker its server runs in).
+    const client = new CompositeClient(rocqOnlySetups(), context);
+    const rocq = rocqDouble(client);
+    rocq.hasClient = true;
+    rocq.isRunning.mockReturnValue(false);
+
+    await client.dispose(10);
+
+    expect(rocq.dispose).toHaveBeenCalledWith(10);
+  });
+
+  it("does not dispose a client that was never created", async () => {
+    // Reading `hasClient` must not be what brings a client into existence.
+    const client = new CompositeClient(rocqOnlySetups(), context);
+    const rocq = rocqDouble(client);
+    rocq.hasClient = false;
+
+    await client.dispose();
+
+    expect(rocq.dispose).not.toHaveBeenCalled();
+  });
+
+  it("does not fail when Lean is unsupported", async () => {
+    const client = new CompositeClient(rocqOnlySetups(), context);
+    rocqDouble(client).hasClient = true;
+
+    await expect(client.dispose()).resolves.toBeUndefined();
+  });
+
+  it("disposes both clients when both were created", async () => {
+    const client = new CompositeClient(bothSetups(), context);
+    rocqDouble(client).hasClient = true;
+    leanDouble(client).hasClient = true;
+
+    await client.dispose();
+
+    expect(rocqDouble(client).dispose).toHaveBeenCalled();
+    expect(leanDouble(client).dispose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/mainBrowser.test.ts
+++ b/__tests__/mainBrowser.test.ts
@@ -1,0 +1,155 @@
+// Unit tests for the web entry point's Rocq client provider.
+//
+// LLM-generated tests that might encode existing faulty behaviour.
+//
+// `vscode-languageclient/browser` only wraps the worker it is handed in a
+// message reader/writer; it never terminates it. `WorkerLanguageClient` closes
+// that gap so restarting the document checker does not leave the previous wacoq
+// worker running. What is covered here:
+//   - the worker being started per client rather than per factory call,
+//   - the worker being terminated when the client is disposed, including when
+//     the LSP shutdown itself fails,
+//   - the entry point declaring Rocq as the only language it supports.
+//
+// `WorkerLanguageClient` is module-private, so the tests reach it the way the
+// extension does: through the `LanguageSupport` that `activate` hands over.
+
+function helperMocks(): typeof import("./__helpers__/browser-client-mocks").browserMocks {
+  return require("./__helpers__/browser-client-mocks").browserMocks; // eslint-disable-line @typescript-eslint/no-require-imports
+}
+
+jest.mock("vscode", () => helperMocks().vscodeModule(), { virtual: true });
+jest.mock(
+  "vscode-languageclient/browser",
+  () => helperMocks().languageClientModule(),
+  { virtual: true },
+);
+jest.mock("../src/extension", () => helperMocks().extensionModule());
+
+import { activate } from "../src/mainBrowser";
+import {
+  baseDispose,
+  FakeWorker,
+  resetBrowserMocks,
+  waterproofInstances,
+} from "./__helpers__/browser-client-mocks";
+import type { ExtensionContext, WorkspaceConfiguration } from "vscode";
+import type { LanguageClientOptions } from "vscode-languageclient";
+import type { LanguageClientProvider } from "../src/lsp-client/clientTypes";
+
+const EXTENSION_URI = "file:///ext";
+const WACOQ_URL = `${EXTENSION_URI}/out/wacoq_worker.js`;
+
+function makeContext(): ExtensionContext {
+  return {
+    extensionUri: { toString: () => EXTENSION_URI },
+    subscriptions: [],
+  } as unknown as ExtensionContext;
+}
+
+/** Run `activate` and return the Rocq provider it registered. */
+function activateAndGetProvider(): LanguageClientProvider {
+  const context = makeContext();
+  activate(context);
+  const { languageSupport } = waterproofInstances[0];
+  return languageSupport.rocq(
+    context,
+    {} as LanguageClientOptions,
+    {} as WorkspaceConfiguration,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetBrowserMocks();
+  (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+  // `activate` announces itself on the console; keep the test output readable.
+  jest.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete (globalThis as { Worker?: unknown }).Worker;
+  jest.restoreAllMocks();
+});
+
+describe("web entry point language support", () => {
+  it("declares Rocq as the only supported language", () => {
+    activate(makeContext());
+
+    const { languageSupport, isWeb } = waterproofInstances[0];
+    expect(languageSupport.rocq).toBeDefined();
+    expect(languageSupport.lean).toBeUndefined();
+    expect(isWeb).toBe(true);
+  });
+});
+
+describe("Rocq client provider worker lifetime", () => {
+  it("starts no worker until a client is actually built", () => {
+    // The factory used to spawn the worker itself, so a provider that was never
+    // called still booted a server.
+    activateAndGetProvider();
+
+    expect(FakeWorker.created).toHaveLength(0);
+  });
+
+  it("starts the wacoq worker and hands it the extension uri", () => {
+    const provider = activateAndGetProvider();
+
+    provider();
+
+    expect(FakeWorker.created).toHaveLength(1);
+    expect(FakeWorker.created[0].url).toBe(WACOQ_URL);
+    expect(FakeWorker.created[0].postMessage).toHaveBeenCalledWith(
+      EXTENSION_URI,
+    );
+  });
+
+  it("gives every client its own worker", () => {
+    const provider = activateAndGetProvider();
+
+    provider();
+    provider();
+
+    expect(FakeWorker.created).toHaveLength(2);
+    expect(FakeWorker.created[0]).not.toBe(FakeWorker.created[1]);
+  });
+});
+
+describe("WorkerLanguageClient.dispose", () => {
+  it("terminates the worker, after shutting the client down", async () => {
+    const client = activateAndGetProvider()();
+    const worker = FakeWorker.created[0];
+
+    await client.dispose(1234);
+
+    expect(baseDispose).toHaveBeenCalledWith(1234);
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    // The worker must outlive the shutdown handshake, not the other way round.
+    expect(baseDispose.mock.invocationCallOrder[0]).toBeLessThan(
+      worker.terminate.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("terminates the worker even when the shutdown fails", async () => {
+    // Otherwise a server that will not shut down cleanly leaks its worker,
+    // which is exactly the case where the worker is most likely to be stuck.
+    baseDispose.mockRejectedValue(new Error("shutdown timed out"));
+    const client = activateAndGetProvider()();
+    const worker = FakeWorker.created[0];
+
+    await expect(client.dispose()).rejects.toThrow("shutdown timed out");
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("terminates only its own worker", async () => {
+    const provider = activateAndGetProvider();
+    const first = provider();
+    provider();
+
+    await first.dispose();
+
+    expect(FakeWorker.created[0].terminate).toHaveBeenCalledTimes(1);
+    expect(FakeWorker.created[1].terminate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/webviews/goalviews/goalsBase.test.ts
+++ b/__tests__/webviews/goalviews/goalsBase.test.ts
@@ -1,0 +1,174 @@
+// Unit tests for GoalsBase.updateGoals and the DebugPanel override.
+//
+// LLM-generated tests that might encode existing faulty behaviour.
+//
+// These panels render Rocq goals, but they are reached two different ways: the
+// CompositeGoalsPanel hands them the Rocq client directly, while the goals
+// components registered on the extension are handed the CompositeClient. The
+// composite has no `requestGoals` of its own, so passing it straight through
+// used to crash with "client.requestGoals is not a function" — swallowed by the
+// try/catch and surfaced only as an empty panel. What is covered here:
+//   - both client shapes resolving to the same Rocq client,
+//   - the failure path posting errorGoals instead of renderGoals,
+//   - DebugPanel activating its panel before delegating.
+//
+// DebugPanel is used as the concrete stand-in for the abstract GoalsBase, since
+// it is also the class that actually receives a CompositeClient in production.
+
+function panelMocks() {
+  class WaterproofPanel {
+    public readonly postMessage = jest.fn(() => true);
+    public readonly activatePanel = jest.fn();
+    public readonly deactivatePanel = jest.fn();
+    public readonly on = jest.fn();
+    constructor(
+      public readonly extensionUri: unknown,
+      public readonly name: string,
+      public readonly supportInsert?: boolean,
+    ) {}
+  }
+  return {
+    WaterproofPanel,
+    WebviewEvents: { change: "change" },
+    WebviewState: { visible: "visible", closed: "closed" },
+  };
+}
+
+jest.mock("vscode", () => ({}), { virtual: true });
+jest.mock("../../../src/webviews/waterproofPanel", () => panelMocks());
+jest.mock("../../../src/helpers", () => ({
+  WaterproofLogger: { log: jest.fn(), debug: jest.fn(), show: jest.fn() },
+  WaterproofConfigHelper: { get: jest.fn(() => "none") },
+  WaterproofSetting: { VisibilityOfHypotheses: "visibilityOfHypotheses" },
+}));
+
+import { DebugPanel } from "../../../src/webviews/goalviews/debug";
+// `MessageType` is a const enum, so its values are inlined at compile time and
+// cannot be mocked; assert against the real ones.
+import { MessageType } from "../../../shared";
+import type { Uri } from "vscode";
+import type { LspClientConfig } from "../../../src/lsp-client/clientTypes";
+import type { CompositeClient } from "../../../src/lsp-client/composite";
+import type { RocqLspClient } from "../../../src/lsp-client/rocq";
+
+/** A Rocq client double that only answers goal requests. */
+function makeRocqClient(): RocqLspClient & { requestGoals: jest.Mock } {
+  return {
+    requestGoals: jest.fn().mockResolvedValue({ goals: { goals: [] } }),
+  } as unknown as RocqLspClient & { requestGoals: jest.Mock };
+}
+
+/**
+ * A composite-client double. Deliberately has no `requestGoals` of its own, so
+ * a panel that asked it directly would throw rather than silently pass.
+ */
+function makeComposite(rocqClient: RocqLspClient): CompositeClient {
+  return { rocqClient } as unknown as CompositeClient;
+}
+
+function makePanel(): DebugPanel & {
+  postMessage: jest.Mock;
+  activatePanel: jest.Mock;
+} {
+  return new DebugPanel({} as Uri, {} as LspClientConfig) as DebugPanel & {
+    postMessage: jest.Mock;
+    activatePanel: jest.Mock;
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GoalsBase.updateGoals client resolution", () => {
+  it("requests goals from a Rocq client passed directly", async () => {
+    const rocq = makeRocqClient();
+    const panel = makePanel();
+
+    await panel.updateGoals(rocq);
+
+    expect(rocq.requestGoals).toHaveBeenCalledTimes(1);
+    expect(panel.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: MessageType.renderGoals }),
+    );
+  });
+
+  it("takes the Rocq client off a CompositeClient", async () => {
+    // Regression test: the composite is what the extension's goals components
+    // are handed, and it has no `requestGoals` of its own.
+    const rocq = makeRocqClient();
+    const composite = makeComposite(rocq);
+    expect("requestGoals" in composite).toBe(false);
+    const panel = makePanel();
+
+    await panel.updateGoals(composite);
+
+    expect(rocq.requestGoals).toHaveBeenCalledTimes(1);
+    expect(panel.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: MessageType.renderGoals }),
+    );
+  });
+
+  it("passes the configured hypothesis visibility along with the goals", async () => {
+    const rocq = makeRocqClient();
+    const goals = { goals: { goals: [{ ty: "nat" }] } };
+    rocq.requestGoals.mockResolvedValue(goals);
+    const panel = makePanel();
+
+    await panel.updateGoals(makeComposite(rocq));
+
+    expect(panel.postMessage).toHaveBeenCalledWith({
+      type: MessageType.renderGoals,
+      body: { goals, visibility: "none" },
+    });
+  });
+});
+
+describe("GoalsBase.updateGoals failure handling", () => {
+  it("posts errorGoals and no goals when the request rejects", async () => {
+    const rocq = makeRocqClient();
+    const error = new Error("no active document");
+    rocq.requestGoals.mockRejectedValue(error);
+    const panel = makePanel();
+
+    await panel.updateGoals(makeComposite(rocq));
+
+    expect(panel.postMessage).toHaveBeenCalledWith({
+      type: MessageType.errorGoals,
+      body: error,
+    });
+    expect(panel.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: MessageType.renderGoals }),
+    );
+  });
+
+  it("posts nothing when the request resolves without goals", async () => {
+    const rocq = makeRocqClient();
+    rocq.requestGoals.mockResolvedValue(undefined);
+    const panel = makePanel();
+
+    await panel.updateGoals(makeComposite(rocq));
+
+    expect(panel.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("DebugPanel.updateGoals", () => {
+  it("activates the panel before delegating to GoalsBase", async () => {
+    const rocq = makeRocqClient();
+    const panel = makePanel();
+
+    await panel.updateGoals(makeComposite(rocq));
+
+    expect(panel.activatePanel).toHaveBeenCalledTimes(1);
+    expect(rocq.requestGoals).toHaveBeenCalledTimes(1);
+  });
+
+  it("activates the panel even when the goal request fails", async () => {
+    const rocq = makeRocqClient();
+    rocq.requestGoals.mockRejectedValue(new Error("boom"));
+    const panel = makePanel();
+
+    await panel.updateGoals(makeComposite(rocq));
+
+    expect(panel.activatePanel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,8 +1,6 @@
 import { Disposable, Position } from "vscode";
 import { RocqGoalAnswer, PpString } from "../lib/types";
 import { FileProgressParams } from "./lsp-client/requestTypes";
-// Type-only: `components` and `lsp-client` import from each other.
-import type { CompositeClient } from "./lsp-client/composite";
 
 /**
  * This defines the interface of a component that displays
@@ -43,35 +41,6 @@ export interface IFileProgressComponent extends Disposable {
    * processed.
    */
   onProgress(params: FileProgressParams): void;
-}
-
-/**
- * This defines the interface of components that display
- * goal and message related information
- */
-export interface IGoalsComponent extends Disposable {
-  /**
-   * Update the goals component with the latest goals answer
-   * from the coq-lsp server
-   *
-   * @param client the composite client to request the goals from. Components
-   *               that can only render the goals of a single language server
-   *               have to pick the relevant client off it themselves.
-   */
-  updateGoals(client: CompositeClient): Promise<void>;
-
-  /**
-   * Update the status bar to indicate failure to start client
-   *
-   * @param e the error that resulted in failure to receive
-   *          goal answer
-   */
-  failedGoals(e: unknown): void;
-
-  /**
-   * Disable the GoalsComponent
-   */
-  disable(): void;
 }
 
 /**

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,7 +1,8 @@
 import { Disposable, Position } from "vscode";
 import { RocqGoalAnswer, PpString } from "../lib/types";
 import { FileProgressParams } from "./lsp-client/requestTypes";
-import { ILspClient } from "./lsp-client/clientTypes";
+// Type-only: `components` and `lsp-client` import from each other.
+import type { CompositeClient } from "./lsp-client/composite";
 
 /**
  * This defines the interface of a component that displays
@@ -53,9 +54,11 @@ export interface IGoalsComponent extends Disposable {
    * Update the goals component with the latest goals answer
    * from the coq-lsp server
    *
-   * @param goals the goal answer object received from coq-lsp
+   * @param client the composite client to request the goals from. Components
+   *               that can only render the goals of a single language server
+   *               have to pick the relevant client off it themselves.
    */
-  updateGoals(client: ILspClient): Promise<void>;
+  updateGoals(client: CompositeClient): Promise<void>;
 
   /**
    * Update the status bar to indicate failure to start client

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,8 @@ import {
   RevealOutputChannelOn,
 } from "vscode-languageclient";
 
-import { IExecutor, IGoalsComponent, IStatusComponent } from "./components";
+import { IExecutor, IStatusComponent } from "./components";
+import { IGoalsComponent } from "./webviews/goalviews/goalsComponent";
 import { WaterproofStatusBar } from "./components/enableButton";
 import {
   LanguageClientProviderFactory,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -860,27 +860,6 @@ export class Waterproof implements Disposable {
       markdown: { isTrusted: true, supportHtml: true },
     };
 
-    wpl.log("Initializing client...");
-    this.client = new CompositeClient(
-      this.getRocqClientProvider(
-        this.context,
-        rocqClientOptions,
-        WaterproofConfigHelper.configuration,
-      ),
-      window.createOutputChannel(
-        "Waterproof Rocq LSP Events (After Initialization)",
-      ),
-      this.getLeanClientProvider(
-        this.context,
-        leanClientOptions,
-        WaterproofConfigHelper.configuration,
-      ),
-      window.createOutputChannel(
-        "Waterproof Lean LSP Events (After Initialization)",
-      ),
-      this.context,
-    );
-
     // Whether the user has decided to skip the launch checks
     let skipLaunchChecksSetting = WaterproofConfigHelper.get(
       WaterproofSetting.SkipLaunchChecks,
@@ -892,6 +871,34 @@ export class Waterproof implements Disposable {
         "Web version detected, automatically skipping launch checks for Rocq and not launching Lean client.",
       );
     }
+
+    // The web version cannot run Lean, so no provider is created for it. This
+    // has to be decided before constructing the `CompositeClient`, which
+    // instantiates every client it is given a provider for.
+    const leanClientProvider = this._isWeb
+      ? undefined
+      : this.getLeanClientProvider(
+          this.context,
+          leanClientOptions,
+          WaterproofConfigHelper.configuration,
+        );
+
+    wpl.log("Initializing client...");
+    this.client = new CompositeClient(
+      this.getRocqClientProvider(
+        this.context,
+        rocqClientOptions,
+        WaterproofConfigHelper.configuration,
+      ),
+      window.createOutputChannel(
+        "Waterproof Rocq LSP Events (After Initialization)",
+      ),
+      leanClientProvider,
+      window.createOutputChannel(
+        "Waterproof Lean LSP Events (After Initialization)",
+      ),
+      this.context,
+    );
     let allowedLanguages: string[] = [];
 
     if (skipLaunchChecksSetting !== "none") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,8 @@ import { IExecutor, IStatusComponent } from "./components";
 import { IGoalsComponent } from "./webviews/goalviews/goalsComponent";
 import { WaterproofStatusBar } from "./components/enableButton";
 import {
-  LanguageClientProviderFactory,
+  LanguageClientSetups,
+  LanguageSupport,
   LspClientConfig,
 } from "./lsp-client/clientTypes";
 import { RocqLspServerConfig } from "./lsp-client/rocq";
@@ -71,10 +72,9 @@ export class Waterproof implements Disposable {
   private readonly disposables: Disposable[] = [];
 
   /** The function that can create a new Rocq language client provider */
-  private readonly getRocqClientProvider: LanguageClientProviderFactory;
+  private readonly languageSupport: LanguageSupport;
 
   /** The function that can create a new Lean language client provider */
-  private readonly getLeanClientProvider: LanguageClientProviderFactory;
 
   /** The manager for (communication between) webviews */
   public readonly webviewManager: WebviewManager;
@@ -108,8 +108,7 @@ export class Waterproof implements Disposable {
    */
   constructor(
     context: ExtensionContext,
-    getRocqClientProvider: LanguageClientProviderFactory,
-    getLeanClientProvider: LanguageClientProviderFactory,
+    languageSupport: LanguageSupport,
     private readonly _isWeb = false,
   ) {
     wpl.log("Waterproof initialized");
@@ -117,8 +116,7 @@ export class Waterproof implements Disposable {
     checkTrimmingWhitespace();
 
     this.context = context;
-    this.getRocqClientProvider = getRocqClientProvider;
-    this.getLeanClientProvider = getLeanClientProvider;
+    this.languageSupport = languageSupport;
 
     this.webviewManager = new WebviewManager();
     // Wire up the webview-manager events. The handlers are defined as methods
@@ -851,55 +849,60 @@ export class Waterproof implements Disposable {
       markdown: { isTrusted: true, supportHtml: true },
     };
 
-    const leanServerOptions = LeanLspServerConfig.create();
-
-    const leanClientOptions: LanguageClientOptions = {
-      documentSelector: [{ language: "lean4" }],
-      outputChannelName: "Waterproof Lean LSP Events (Initial)",
-      revealOutputChannelOn: RevealOutputChannelOn.Info,
-      initializationOptions: leanServerOptions,
-      markdown: { isTrusted: true, supportHtml: true },
-    };
-
     // Whether the user has decided to skip the launch checks
     let skipLaunchChecksSetting = WaterproofConfigHelper.get(
       WaterproofSetting.SkipLaunchChecks,
     );
     if (this._isWeb) {
-      // In the web version, we only support rocq
+      // The prelaunch checks shell out through `child_process` to inspect the
+      // installed tooling, which the web extension cannot do. Skip them and
+      // start the only server a web build can run.
       skipLaunchChecksSetting = "rocq";
       wpl.log(
-        "Web version detected, automatically skipping launch checks for Rocq and not launching Lean client.",
+        "Web version detected, skipping launch checks and starting only the Rocq client.",
       );
     }
 
-    // The web version cannot run Lean, so no provider is created for it. This
-    // has to be decided before constructing the `CompositeClient`, which
-    // instantiates every client it is given a provider for.
-    const leanClientProvider = this._isWeb
-      ? undefined
-      : this.getLeanClientProvider(
+    const clientSetups: LanguageClientSetups = {
+      rocq: {
+        provider: this.languageSupport.rocq(
+          this.context,
+          rocqClientOptions,
+          WaterproofConfigHelper.configuration,
+        ),
+        createOutputChannel: () =>
+          window.createOutputChannel(
+            "Waterproof Rocq LSP Events (After Initialization)",
+          ),
+      },
+    };
+
+    // Lean is only configured when the entry point supplies a factory for it;
+    // the web build does not, as it cannot spawn a Lake process.
+    const getLeanClientProvider = this.languageSupport.lean;
+    if (getLeanClientProvider) {
+      const leanClientOptions: LanguageClientOptions = {
+        documentSelector: [{ language: "lean4" }],
+        outputChannelName: "Waterproof Lean LSP Events (Initial)",
+        revealOutputChannelOn: RevealOutputChannelOn.Info,
+        initializationOptions: LeanLspServerConfig.create(),
+        markdown: { isTrusted: true, supportHtml: true },
+      };
+      clientSetups.lean = {
+        provider: getLeanClientProvider(
           this.context,
           leanClientOptions,
           WaterproofConfigHelper.configuration,
-        );
+        ),
+        createOutputChannel: () =>
+          window.createOutputChannel(
+            "Waterproof Lean LSP Events (After Initialization)",
+          ),
+      };
+    }
 
     wpl.log("Initializing client...");
-    this.client = new CompositeClient(
-      this.getRocqClientProvider(
-        this.context,
-        rocqClientOptions,
-        WaterproofConfigHelper.configuration,
-      ),
-      window.createOutputChannel(
-        "Waterproof Rocq LSP Events (After Initialization)",
-      ),
-      leanClientProvider,
-      window.createOutputChannel(
-        "Waterproof Lean LSP Events (After Initialization)",
-      ),
-      this.context,
-    );
+    this.client = new CompositeClient(clientSetups, this.context);
     let allowedLanguages: string[] = [];
 
     if (skipLaunchChecksSetting !== "none") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -961,12 +961,14 @@ export class Waterproof implements Disposable {
    * Disposes of the Rocq LSP client.
    */
   private async stopClient(): Promise<void> {
-    if (this.client.isRunning()) {
-      await this.client.dispose(2000);
+    const wasRunning = this.client.isRunning();
+    // Dispose unconditionally rather than only when running: a client that was
+    // created but failed to start still owns resources, and would otherwise be
+    // orphaned by the next `initializeClient`.
+    await this.client.dispose(2000);
+    if (wasRunning) {
       this.clientRunning = false;
       this.statusBar.update([]);
-    } else {
-      return Promise.resolve();
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,10 +71,8 @@ export class Waterproof implements Disposable {
   /** The resources that must be released when this extension is disposed of */
   private readonly disposables: Disposable[] = [];
 
-  /** The function that can create a new Rocq language client provider */
+  /** The languages this build can create language clients for */
   private readonly languageSupport: LanguageSupport;
-
-  /** The function that can create a new Lean language client provider */
 
   /** The manager for (communication between) webviews */
   public readonly webviewManager: WebviewManager;

--- a/src/lsp-client/client.ts
+++ b/src/lsp-client/client.ts
@@ -83,6 +83,18 @@ export abstract class LspClient<
   }
 
   /**
+   * Whether the underlying client has been created.
+   *
+   * Unlike `isRunning`, reading this never creates one, and it stays true for a
+   * client that was created but failed to start. Such a client still owns
+   * resources that have to be released — in the web build, the worker its
+   * server runs in.
+   */
+  get hasClient(): boolean {
+    return this._client !== undefined;
+  }
+
+  /**
    * Checks whether the underlying client exists and is running.
    */
   isRunning(): boolean {

--- a/src/lsp-client/clientTypes.ts
+++ b/src/lsp-client/clientTypes.ts
@@ -7,6 +7,7 @@ import {
   ExtensionContext,
   WorkspaceConfiguration,
   Disposable,
+  OutputChannel,
   Position,
   TextDocument,
 } from "vscode";
@@ -31,6 +32,37 @@ export type LanguageClientProviderFactory = (
   clientOptions: LanguageClientOptions,
   wsConfig: WorkspaceConfiguration,
 ) => LanguageClientProvider;
+
+/**
+ * Everything needed to bring up the client for a single language.
+ *
+ * The provider and the output channel are grouped so that a language is either
+ * fully configured or entirely absent; the channel is created lazily, so a
+ * language this build does not support leaves no empty channel behind in the
+ * Output dropdown.
+ */
+export interface LanguageClientSetup {
+  provider: LanguageClientProvider;
+  createOutputChannel: () => OutputChannel;
+}
+
+/** The per-language setups the `CompositeClient` is built from. */
+export interface LanguageClientSetups {
+  rocq: LanguageClientSetup;
+  lean?: LanguageClientSetup;
+}
+
+/**
+ * The languages an entry point can provide clients for.
+ *
+ * `lean` is absent in builds that cannot run a Lean server, such as the web
+ * extension, which has no way to spawn a Lake process. Leaving it out is what
+ * makes a language unsupported; there is no separate flag to keep in sync.
+ */
+export interface LanguageSupport {
+  rocq: LanguageClientProviderFactory;
+  lean?: LanguageClientProviderFactory;
+}
 
 export interface ILspClient extends TimeoutDisposable {
   /**

--- a/src/lsp-client/composite.ts
+++ b/src/lsp-client/composite.ts
@@ -198,10 +198,13 @@ export class CompositeClient implements ILspClient {
 
   async dispose(timeout?: number): Promise<void> {
     const disposePromises = [];
-    if (this.rocqClient.isRunning()) {
+    // Dispose every client that was created, not only the running ones: a
+    // client that failed to start still owns resources. Disposing a client that
+    // never started is a no-op on the language client itself.
+    if (this.rocqClient.hasClient) {
       disposePromises.push(this.rocqClient.dispose(timeout));
     }
-    if (this.leanClient?.isRunning()) {
+    if (this.leanClient?.hasClient) {
       disposePromises.push(this.leanClient.dispose(timeout));
     }
     await Promise.all(disposePromises);

--- a/src/lsp-client/composite.ts
+++ b/src/lsp-client/composite.ts
@@ -1,14 +1,9 @@
 import { LeanLspClient } from "./lean";
 import { RocqLspClient } from "./rocq";
 import { convertToString } from "../../lib/types";
-import { ILspClient, LanguageClientProvider } from "./clientTypes";
+import { ILspClient, LanguageClientSetups } from "./clientTypes";
 import { WaterproofLogger as wpl } from "../helpers";
-import {
-  ExtensionContext,
-  OutputChannel,
-  Position,
-  TextDocument,
-} from "vscode";
+import { ExtensionContext, Position, TextDocument } from "vscode";
 import { DocumentSymbol } from "vscode-languageserver-types";
 import { Hypothesis } from "../api";
 import { WebviewManager } from "../webviewManager";
@@ -24,22 +19,20 @@ export class CompositeClient implements ILspClient {
 
   protected document?: TextDocument;
 
-  constructor(
-    rocqClientProvider: LanguageClientProvider,
-    rocqOutputChannel: OutputChannel,
-    leanClientProvider: LanguageClientProvider | undefined,
-    leanOutputChannel: OutputChannel,
-    context: ExtensionContext,
-  ) {
+  constructor(clients: LanguageClientSetups, context: ExtensionContext) {
     this.rocqClient = new RocqLspClient(
-      rocqClientProvider,
-      rocqOutputChannel,
+      clients.rocq.provider,
+      clients.rocq.createOutputChannel(),
       context,
     );
-    // Constructing a client eagerly instantiates its underlying `LanguageClient`,
-    // so only do so when Lean is actually supported.
-    this.leanClient = leanClientProvider
-      ? new LeanLspClient(leanClientProvider, leanOutputChannel)
+    // Constructing a client eagerly instantiates its underlying `LanguageClient`
+    // and its output channel, so only do so for the languages this build
+    // actually supports.
+    this.leanClient = clients.lean
+      ? new LeanLspClient(
+          clients.lean.provider,
+          clients.lean.createOutputChannel(),
+        )
       : undefined;
 
     this.lastClient = this.rocqClient;

--- a/src/lsp-client/composite.ts
+++ b/src/lsp-client/composite.ts
@@ -15,7 +15,11 @@ import { WebviewManager } from "../webviewManager";
 
 export class CompositeClient implements ILspClient {
   public readonly rocqClient: RocqLspClient;
-  public readonly leanClient: LeanLspClient;
+  /**
+   * The Lean client, or `undefined` when Lean is not supported by this build
+   * (e.g. the web extension, which has no way to spawn a Lake process).
+   */
+  public readonly leanClient?: LeanLspClient;
   protected readonly lastClient: RocqLspClient | LeanLspClient;
 
   protected document?: TextDocument;
@@ -23,7 +27,7 @@ export class CompositeClient implements ILspClient {
   constructor(
     rocqClientProvider: LanguageClientProvider,
     rocqOutputChannel: OutputChannel,
-    leanClientProvider: LanguageClientProvider,
+    leanClientProvider: LanguageClientProvider | undefined,
     leanOutputChannel: OutputChannel,
     context: ExtensionContext,
   ) {
@@ -32,7 +36,11 @@ export class CompositeClient implements ILspClient {
       rocqOutputChannel,
       context,
     );
-    this.leanClient = new LeanLspClient(leanClientProvider, leanOutputChannel);
+    // Constructing a client eagerly instantiates its underlying `LanguageClient`,
+    // so only do so when Lean is actually supported.
+    this.leanClient = leanClientProvider
+      ? new LeanLspClient(leanClientProvider, leanOutputChannel)
+      : undefined;
 
     this.lastClient = this.rocqClient;
   }
@@ -61,7 +69,8 @@ export class CompositeClient implements ILspClient {
   }
 
   protected getClient(document: TextDocument): RocqLspClient | LeanLspClient {
-    if (document?.languageId === "lean4") return this.leanClient;
+    if (document?.languageId === "lean4" && this.leanClient)
+      return this.leanClient;
     else return this.rocqClient;
   }
 
@@ -137,7 +146,7 @@ export class CompositeClient implements ILspClient {
   async prelaunchChecks(): Promise<string[]> {
     const [rocqAllowed, leanAllowed] = await Promise.all([
       this.rocqClient.prelaunchChecks(),
-      this.leanClient.prelaunchChecks(),
+      this.leanClient?.prelaunchChecks() ?? [],
     ]);
 
     return [...rocqAllowed, ...leanAllowed];
@@ -147,20 +156,27 @@ export class CompositeClient implements ILspClient {
    * Check if all clients are running.
    */
   isRunning(): boolean {
-    return this.rocqClient.isRunning() || this.leanClient.isRunning();
+    return (
+      this.rocqClient.isRunning() || (this.leanClient?.isRunning() ?? false)
+    );
   }
 
   async startWithHandlers(
     webviewManager: WebviewManager,
     allowedLanguages: string[],
   ): Promise<string[]> {
+    const leanClient = this.leanClient;
     const rocqAllowed = allowedLanguages.includes(this.rocqClient.language);
-    const leanAllowed = allowedLanguages.includes(this.leanClient.language);
+    const leanAllowed =
+      leanClient !== undefined &&
+      allowedLanguages.includes(leanClient.language);
 
     if (!rocqAllowed) {
       wpl.log("Skipping Rocq client start: prelaunch checks failed.");
     }
-    if (!leanAllowed) {
+    if (leanClient === undefined) {
+      wpl.log("Skipping Lean client start: Lean is not supported.");
+    } else if (!leanAllowed) {
       wpl.log("Skipping Lean client start: prelaunch checks failed.");
     }
 
@@ -174,7 +190,7 @@ export class CompositeClient implements ILspClient {
       : Promise.resolve([]);
 
     const leanStart = leanAllowed
-      ? this.leanClient
+      ? leanClient
           .startWithHandlers(webviewManager, allowedLanguages)
           .catch((err) => {
             wpl.log(`Failed to start Lean client: ${err}`);
@@ -192,7 +208,7 @@ export class CompositeClient implements ILspClient {
     if (this.rocqClient.isRunning()) {
       disposePromises.push(this.rocqClient.dispose(timeout));
     }
-    if (this.leanClient.isRunning()) {
+    if (this.leanClient?.isRunning()) {
       disposePromises.push(this.leanClient.dispose(timeout));
     }
     await Promise.all(disposePromises);

--- a/src/mainBrowser.ts
+++ b/src/mainBrowser.ts
@@ -31,32 +31,13 @@ const getRocqClientProvider: LanguageClientProviderFactory = (
     );
 };
 
-/**
- * Lean is not supported in the web version: there is no way to spawn the Lake
- * process the Lean server needs. The extension gates on this and never asks for
- * a Lean client, so the returned provider only exists as a backstop; note that
- * it must not throw here, as the factory itself is called during activation.
- *
- * @param clientOptions the options available for a LanguageClient (see vscode api)
- * @param wsConfig the workspace configuration of Waterproof
- * @returns a provider that rejects any attempt to create a Lean client
- */
-const getLeanClientProvider: LanguageClientProviderFactory = (
-  _context: ExtensionContext,
-  _clientOptions: LanguageClientOptions,
-  _wsConfig: WorkspaceConfiguration,
-) => {
-  return () => {
-    throw new Error("Lean is not supported in the web version of Waterproof");
-  };
-};
-
 export function activate(context: ExtensionContext): void {
   console.log("Browser activate function");
+  // No `lean` entry: this build cannot spawn the Lake process a Lean server
+  // needs, so it declares Rocq as the only language it supports.
   const extension: Waterproof = new Waterproof(
     context,
-    getRocqClientProvider,
-    getLeanClientProvider,
+    { rocq: getRocqClientProvider },
     true,
   );
   context.subscriptions.push(extension);

--- a/src/mainBrowser.ts
+++ b/src/mainBrowser.ts
@@ -7,6 +7,39 @@ import {
 import { Waterproof } from "./extension";
 
 /**
+ * A `LanguageClient` that owns the web worker its server runs in.
+ *
+ * `vscode-languageclient/browser` only wraps the worker it is handed in a
+ * message reader/writer; it never terminates it. Without this, restarting the
+ * document checker would leave the previous wacoq worker running forever, each
+ * one holding the filesystem it unzipped out of `core-fs.zip` and its own idle
+ * loop.
+ */
+class WorkerLanguageClient extends LanguageClient {
+  // Not named `worker`: the base class already declares a private field by
+  // that name.
+  private readonly lspWorker: Worker;
+
+  constructor(
+    worker: Worker,
+    id: string,
+    name: string,
+    clientOptions: LanguageClientOptions,
+  ) {
+    super(id, name, clientOptions, worker);
+    this.lspWorker = worker;
+  }
+
+  override async dispose(timeout?: number): Promise<void> {
+    try {
+      await super.dispose(timeout);
+    } finally {
+      this.lspWorker.terminate();
+    }
+  }
+}
+
+/**
  * This function is responsible for creating Rocq language client providers
  *
  * @param clientOptions the options available for a LanguageClient (see vscode api)
@@ -18,17 +51,21 @@ const getRocqClientProvider: LanguageClientProviderFactory = (
   clientOptions: LanguageClientOptions,
   _wsConfig: WorkspaceConfiguration,
 ) => {
-  const lspWorker = new Worker(
-    Uri.joinPath(context.extensionUri, "out/wacoq_worker.js").toString(true),
-  );
-  lspWorker.postMessage(context.extensionUri.toString());
-  return () =>
-    new LanguageClient(
+  // The worker is started by the provider rather than here, so that its
+  // lifetime matches the client that terminates it. A provider that is never
+  // called leaves no worker behind.
+  return () => {
+    const lspWorker = new Worker(
+      Uri.joinPath(context.extensionUri, "out/wacoq_worker.js").toString(true),
+    );
+    lspWorker.postMessage(context.extensionUri.toString());
+    return new WorkerLanguageClient(
+      lspWorker,
       "waterproof",
       "Waterproof Document Checker",
       clientOptions,
-      lspWorker,
     );
+  };
 };
 
 export function activate(context: ExtensionContext): void {

--- a/src/mainBrowser.ts
+++ b/src/mainBrowser.ts
@@ -18,12 +18,6 @@ const getRocqClientProvider: LanguageClientProviderFactory = (
   clientOptions: LanguageClientOptions,
   _wsConfig: WorkspaceConfiguration,
 ) => {
-  const serverMain = Uri.joinPath(
-    context.extensionUri,
-    "out/src/mainBrowser.js",
-  );
-  // Start our own webworker
-  new Worker(serverMain.toString(true));
   const lspWorker = new Worker(
     Uri.joinPath(context.extensionUri, "out/wacoq_worker.js").toString(true),
   );
@@ -38,18 +32,23 @@ const getRocqClientProvider: LanguageClientProviderFactory = (
 };
 
 /**
- * This function is responsible for creating Lean language client providers
+ * Lean is not supported in the web version: there is no way to spawn the Lake
+ * process the Lean server needs. The extension gates on this and never asks for
+ * a Lean client, so the returned provider only exists as a backstop; note that
+ * it must not throw here, as the factory itself is called during activation.
  *
  * @param clientOptions the options available for a LanguageClient (see vscode api)
  * @param wsConfig the workspace configuration of Waterproof
- * @returns an LSP client with the added functionality of `LeanFeatures`
+ * @returns a provider that rejects any attempt to create a Lean client
  */
 const getLeanClientProvider: LanguageClientProviderFactory = (
   _context: ExtensionContext,
   _clientOptions: LanguageClientOptions,
   _wsConfig: WorkspaceConfiguration,
 ) => {
-  throw new Error("Not implemented");
+  return () => {
+    throw new Error("Lean is not supported in the web version of Waterproof");
+  };
 };
 
 export function activate(context: ExtensionContext): void {

--- a/src/mainNode.ts
+++ b/src/mainNode.ts
@@ -68,8 +68,7 @@ const getLeanClientProvider: LanguageClientProviderFactory = (
 export function activate(context: ExtensionContext): WaterproofAPI {
   const extension = new Waterproof(
     context,
-    getRocqClientProvider,
-    getLeanClientProvider,
+    { rocq: getRocqClientProvider, lean: getLeanClientProvider },
     false,
   );
   context.subscriptions.push(extension);

--- a/src/pm-editor/waterproofWebview.ts
+++ b/src/pm-editor/waterproofWebview.ts
@@ -19,9 +19,6 @@ import { SequentialEditor } from "./edit";
 import { getFormatFromExtension, isIllegalFileName } from "./fileUtils";
 
 const SAVE_AS = "Save As";
-
-/** How long to wait for the editor webview to report itself ready. */
-const READY_TIMEOUT_MS = 10_000;
 import {
   qualifiedSettingName,
   WaterproofConfigHelper,
@@ -38,6 +35,9 @@ import {
   ThemeStyle,
   WrappingDocChange,
 } from "@impermeable/waterproof-editor";
+
+/** How long to wait for the editor webview to report itself ready. */
+const READY_TIMEOUT_MS = 10_000;
 
 export class WaterproofWebview extends EventEmitter {
   /** The webview panel of this ProseMirror instance */

--- a/src/pm-editor/waterproofWebview.ts
+++ b/src/pm-editor/waterproofWebview.ts
@@ -19,6 +19,9 @@ import { SequentialEditor } from "./edit";
 import { getFormatFromExtension, isIllegalFileName } from "./fileUtils";
 
 const SAVE_AS = "Save As";
+
+/** How long to wait for the editor webview to report itself ready. */
+const READY_TIMEOUT_MS = 10_000;
 import {
   qualifiedSettingName,
   WaterproofConfigHelper,
@@ -79,6 +82,15 @@ export class WaterproofWebview extends EventEmitter {
    * per type is cached.
    */
   private _cachedMessages: Map<MessageType, Message>;
+
+  /**
+   * Watchdog for the editor bundle: the webview only renders once it has sent
+   * `MessageType.ready`, at which point we answer with the document contents. If
+   * `editor_output/index.js` fails to load or throws while evaluating, that
+   * message never arrives and the editor stays blank with no error on the
+   * extension side, so time it out and say so.
+   */
+  private _readyTimeout?: ReturnType<typeof setTimeout>;
 
   /** Checks whether the document is currently being changed */
   get documentIsUpToDate() {
@@ -306,6 +318,7 @@ export class WaterproofWebview extends EventEmitter {
 
     this._disposables.push(
       this._panel.onDidDispose(() => {
+        clearTimeout(this._readyTimeout);
         this._panel.dispose();
         for (const d of this._disposables) {
           d.dispose();
@@ -370,6 +383,19 @@ export class WaterproofWebview extends EventEmitter {
         </body>
         </html>
         `;
+    WaterproofLogger.debug(
+      `[editor] webview html set for ${WaterproofFileUtil.getBasename(this._document.uri)}, script=${scriptUri}`,
+    );
+    this._readyTimeout = setTimeout(() => {
+      this._readyTimeout = undefined;
+      WaterproofLogger.log(
+        `[editor] No 'ready' message from the editor webview after ${READY_TIMEOUT_MS}ms. ` +
+          `The editor will stay blank. This usually means the bundle at ${scriptUri} ` +
+          `failed to load or threw while evaluating; check the webview devtools ` +
+          `(Developer: Open Webview Developer Tools).`,
+      );
+    }, READY_TIMEOUT_MS);
+
     // TODO: find a proper way to do this
     this.themeUpdate();
   }
@@ -567,6 +593,11 @@ export class WaterproofWebview extends EventEmitter {
         this.handleChangeFromEditor(msg.body);
         break;
       case MessageType.ready:
+        if (this._readyTimeout !== undefined) {
+          clearTimeout(this._readyTimeout);
+          this._readyTimeout = undefined;
+        }
+        WaterproofLogger.debug("[editor] webview reported ready, syncing");
         this.syncWebview();
         // When ready send the state of the teacher mode and show menu items settings to editor
         this.updateTeacherMode();

--- a/src/webviews/goalviews/compositeGoalsPanel.ts
+++ b/src/webviews/goalviews/compositeGoalsPanel.ts
@@ -1,6 +1,6 @@
 import { CompositeClient } from "../../lsp-client/composite";
 import { GoalsPanel } from "./goalsPanel";
-import { IGoalsComponent } from "../../components";
+import { IGoalsComponent } from "./goalsComponent";
 import { LeanLspClient } from "../../lsp-client/lean";
 import { InfoProvider } from "../../infoview";
 import { Location } from "vscode-languageserver-types";

--- a/src/webviews/goalviews/debug.ts
+++ b/src/webviews/goalviews/debug.ts
@@ -3,6 +3,7 @@ import { LspClientConfig } from "../../lsp-client/clientTypes";
 import { WebviewEvents, WebviewState } from "../waterproofPanel";
 import { GoalsBase } from "./goalsBase";
 import { RocqLspClient } from "../../lsp-client/rocq";
+import type { CompositeClient } from "../../lsp-client/composite";
 
 //the debug panel extends the GoalsBase class
 export class DebugPanel extends GoalsBase {
@@ -16,7 +17,7 @@ export class DebugPanel extends GoalsBase {
   }
 
   //override updateGoals to activate the panel before posting the goals message
-  override updateGoals(client: RocqLspClient): Promise<void> {
+  override updateGoals(client: RocqLspClient | CompositeClient): Promise<void> {
     this.activatePanel();
     return super.updateGoals(client);
   }

--- a/src/webviews/goalviews/debug.ts
+++ b/src/webviews/goalviews/debug.ts
@@ -3,7 +3,7 @@ import { LspClientConfig } from "../../lsp-client/clientTypes";
 import { WebviewEvents, WebviewState } from "../waterproofPanel";
 import { GoalsBase } from "./goalsBase";
 import { RocqLspClient } from "../../lsp-client/rocq";
-import type { CompositeClient } from "../../lsp-client/composite";
+import { CompositeClient } from "../../lsp-client/composite";
 
 //the debug panel extends the GoalsBase class
 export class DebugPanel extends GoalsBase {

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -3,6 +3,8 @@ import { RocqGoalAnswer, PpString } from "../../../lib/types";
 import { MessageType } from "../../../shared";
 import { IGoalsComponent } from "../../components";
 import { LspClientConfig } from "../../lsp-client/clientTypes";
+// Type-only: `components` and `lsp-client` import from each other.
+import type { CompositeClient } from "../../lsp-client/composite";
 import { WaterproofPanel } from "../waterproofPanel";
 import { WaterproofConfigHelper, WaterproofSetting } from "../../helpers";
 import { RocqLspClient } from "../../lsp-client/rocq";
@@ -29,11 +31,19 @@ export abstract class GoalsBase
     return client.requestGoals();
   }
 
-  //sends message for renderGoals
-  async updateGoals(client: RocqLspClient): Promise<void> {
+  /**
+   * Sends message for renderGoals.
+   *
+   * These panels render Rocq goals, so they accept either the Rocq client
+   * directly (as `CompositeGoalsPanel` passes it) or the `CompositeClient` (as
+   * the goals components registered on the extension are given), picking the
+   * Rocq client off the latter. The composite itself has no `requestGoals`.
+   */
+  async updateGoals(client: RocqLspClient | CompositeClient): Promise<void> {
+    const rocqClient = "rocqClient" in client ? client.rocqClient : client;
     let goals: RocqGoalAnswer<PpString>;
     try {
-      goals = await this.getGoals(client);
+      goals = await this.getGoals(rocqClient);
     } catch (error) {
       wpl.debug(`Failed to retrieve goals: ${error}`);
       this.failedGoals(error);

--- a/src/webviews/goalviews/goalsBase.ts
+++ b/src/webviews/goalviews/goalsBase.ts
@@ -1,10 +1,9 @@
 import { Uri } from "vscode";
 import { RocqGoalAnswer, PpString } from "../../../lib/types";
 import { MessageType } from "../../../shared";
-import { IGoalsComponent } from "../../components";
 import { LspClientConfig } from "../../lsp-client/clientTypes";
-// Type-only: `components` and `lsp-client` import from each other.
-import type { CompositeClient } from "../../lsp-client/composite";
+import { CompositeClient } from "../../lsp-client/composite";
+import { IGoalsComponent } from "./goalsComponent";
 import { WaterproofPanel } from "../waterproofPanel";
 import { WaterproofConfigHelper, WaterproofSetting } from "../../helpers";
 import { RocqLspClient } from "../../lsp-client/rocq";

--- a/src/webviews/goalviews/goalsComponent.ts
+++ b/src/webviews/goalviews/goalsComponent.ts
@@ -1,0 +1,36 @@
+import { Disposable } from "vscode";
+import { CompositeClient } from "../../lsp-client/composite";
+
+/**
+ * This defines the interface of components that display
+ * goal and message related information.
+ *
+ * This lives next to its implementations rather than in `src/components.ts`,
+ * because it names the `CompositeClient`: the lsp-client layer imports the
+ * component interfaces from there, so declaring it in that module would make
+ * `components` and `lsp-client` mutually dependent.
+ */
+export interface IGoalsComponent extends Disposable {
+  /**
+   * Update the goals component with the latest goals answer
+   * from the coq-lsp server
+   *
+   * @param client the composite client to request the goals from. Components
+   *               that can only render the goals of a single language server
+   *               have to pick the relevant client off it themselves.
+   */
+  updateGoals(client: CompositeClient): Promise<void>;
+
+  /**
+   * Update the status bar to indicate failure to start client
+   *
+   * @param e the error that resulted in failure to receive
+   *          goal answer
+   */
+  failedGoals(e: unknown): void;
+
+  /**
+   * Disable the GoalsComponent
+   */
+  disable(): void;
+}


### PR DESCRIPTION
Fixes the webextension being broken (reported by Bart van den Dries) and probably the webextension having a memory leak (#364).

The webextension being broken was due the way the Lean and Rocq code paths were working in relation to isWeb. This has been slightly refactored.

Testing:

1. Run with the run task "Run as Webextension" and check that this works with a .mv file.
2. Spot check if this does not break the installed Rocq/Lean use

I have generated some tests to get a reasonable coverage on the changes, the remaining uncovered code is not really suitable for tests, in my opinion.